### PR TITLE
[GEN-736] Add debug mode and production parameter for bpc

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,15 +210,15 @@ You can visit [parameters](https://github.com/Sage-Bionetworks/genie-bpc-pipelin
 
 1. For an ec2 instance with Linux and docker, see here for installing Java 11: [How do I install a software package from the Extras Library on an EC2 instance running Amazon Linux 2?](https://aws.amazon.com/premiumsupport/knowledge-center/ec2-install-extras-library-software/)
 
-1. Install nextflow by following instructions here: [Get started — Nextflow](https://www.nextflow.io/docs/latest/getstarted.html#get-started)
+1. Install nextflow by following instructions here: [Get started — Nextflow](https://www.nextflow.io/docs/latest/getstarted.html#get-started). Update your `PATH` variable to include the directory where your nextflow executable is installed at.
 
-- Update PATH to include directory where your nextflow executable is
+1. Make sure to set any nextflow secrets using the Nextflow Cli: [Secrets — Nextflow](https://www.nextflow.io/docs/latest/secrets.html#command-line). You will need to set a `SYNAPSE_AUTH_TOKEN` secret for running the nextflow genie repo by doing 
 
-1. Make sure to set any nextflow secrets using the Nextflow Cli: [Secrets — Nextflow](https://www.nextflow.io/docs/latest/secrets.html#command-line)
+```
+nextflow secrets set SYNAPSE_AUTH_TOKEN “INSERT YOUR SYNAPSE TOKEN HERE”
+```
 
-- You will need to set a SYNAPSE_AUTH_TOKEN secret for running the nextflow genie repo by doing nextflow secrets set SYNAPSE_AUTH_TOKEN “INSERT YOUR SYNAPSE TOKEN HERE”
-
-1. Make any changes
+1. Make any changes to `main.nf`
 
 1. Run the pipeline
 

--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ or store in ~/.synapseConfig with the following format:
 authtoken = {your_personal_access_token_here}
 ```
 
+## Usage: running the genie bpc nextflow pipeline
+
+Skip to this section to learn about how to develop and run the nextflow pipeline locally: ([nextflow development](#nextflow-development))
+
 ## Usage: case selection
 
 To display the command line interface:
@@ -184,13 +188,13 @@ For GENIE BPC, here are the specification recommendations when launching an EC2 
 - EC2 Instance Type: t3.2xlarge
 - Disk size: ~100 GB
 
-### Dependencies
+### Nextflow Dependencies
 
 - [Java 8 or later](https://www.java.com/en/download/)
 - [Nextflow 22.10.x or earlier](https://www.nextflow.io/docs/latest/getstarted.html#get-started)
 
 
-### Configuration
+### Nextflow Configuration
 
 Prior to running the pipeline, you will need to create a Nextflow secret called `SYNAPSE_AUTH_TOKEN`
 with a Synapse personal access token ([docs](#authentication)).
@@ -210,17 +214,17 @@ You can visit [parameters](https://github.com/Sage-Bionetworks/genie-bpc-pipelin
 
 1. For an ec2 instance with Linux and docker, see here for installing Java 11: [How do I install a software package from the Extras Library on an EC2 instance running Amazon Linux 2?](https://aws.amazon.com/premiumsupport/knowledge-center/ec2-install-extras-library-software/)
 
-1. Install nextflow by following instructions here: [Get started — Nextflow](https://www.nextflow.io/docs/latest/getstarted.html#get-started). Update your `PATH` variable to include the directory where your nextflow executable is installed at.
+2. Install nextflow by following instructions here: [Get started — Nextflow](https://www.nextflow.io/docs/latest/getstarted.html#get-started). Update your `PATH` variable to include the directory where your nextflow executable is installed at.
 
-1. Make sure to set any nextflow secrets using the Nextflow Cli: [Secrets — Nextflow](https://www.nextflow.io/docs/latest/secrets.html#command-line). You will need to set a `SYNAPSE_AUTH_TOKEN` secret for running the nextflow genie repo by doing 
+3. Make sure to set any nextflow secrets using the Nextflow Cli: [Secrets — Nextflow](https://www.nextflow.io/docs/latest/secrets.html#command-line). You will need to set a `SYNAPSE_AUTH_TOKEN` secret for running the nextflow genie repo by doing 
 
 ```
 nextflow secrets set SYNAPSE_AUTH_TOKEN “INSERT YOUR SYNAPSE TOKEN HERE”
 ```
 
-1. Make any changes to `main.nf`
+4. Make any changes to `main.nf`
 
-1. Run the pipeline
+5. Run the pipeline
 
 ```bash
 nextflow main.nf

--- a/README.md
+++ b/README.md
@@ -170,4 +170,64 @@ To conduct case selection for a new site, modify the `config.yaml` file. Add in 
 During curation, sites may find cases to be ineligible and may have no additional case for which to substitute the ineligible case.  To account for expected reductions in the target count, update the `adjusted` target number in the `config.yaml` file.  These numbers will then be reflected in the `Case Selection Counts` Table on Synapse (syn26228746) and used in the QA checks to verify the number of submitted cases from each site matches the adjusted target.  
 
 ### Selection of additional samples
-After initial case selection and curation, additional samples for selected cases may be submitted through the main GENIE releases.  These additional samples are collected for curators upon request.  These cohorts are defined in much the same way as other cohorts but without production targets.  See format under the `1_additional` key in the `config.yaml` file for an example.  
+After initial case selection and curation, additional samples for selected cases may be submitted through the main GENIE releases.  These additional samples are collected for curators upon request.  These cohorts are defined in much the same way as other cohorts but without production targets.  See format under the `1_additional` key in the `config.yaml` file for an example.
+
+## Nextflow development
+
+Follow instructions here for running the genie BPC pipeline nextflow workflow locally
+
+An EC2 instance is **required** to run processing and develop locally. Follow instructions using [Service-Catalog-Provisioning](https://help.sc.sageit.org/sc/Service-Catalog-Provisioning.938836322.html) to create an ec2 on service catalog. You will also want to follow the section [SSM with SSH](https://help.sc.sageit.org/sc/Service-Catalog-Provisioning.938836322.html#ServiceCatalogProvisioning-SSMwithSSH) if you want to use VS code to run/develop.
+
+For GENIE BPC, here are the specification recommendations when launching an EC2 instance:
+
+- EC2 Product: Linux with Docker
+- EC2 Instance Type: t3.2xlarge
+- Disk size: ~100 GB
+
+### Dependencies
+
+- [Java 8 or later](https://www.java.com/en/download/)
+- [Nextflow 22.10.x or earlier](https://www.nextflow.io/docs/latest/getstarted.html#get-started)
+
+
+### Configuration
+
+Prior to running the pipeline, you will need to create a Nextflow secret called `SYNAPSE_AUTH_TOKEN`
+with a Synapse personal access token ([docs](#authentication)).
+
+### Authentication
+
+This workflow takes care of transferring files to and from Synapse. Hence, it requires a secret with a personal access token for authentication. To configure Nextflow with such a token, follow these steps:
+
+1. Generate a personal access token (PAT) on Synapse using [this dashboard](https://www.synapse.org/#!PersonalAccessTokens:). Make sure to enable the `view`, `download`, and `modify` scopes since this workflow both downloads and uploads to Synapse.
+2. Create a secret called `SYNAPSE_AUTH_TOKEN` containing a Synapse personal access token using the [Nextflow CLI](https://nextflow.io/docs/latest/secrets.html)
+
+### Commands
+
+You can visit [parameters](https://github.com/Sage-Bionetworks/genie-bpc-pipeline/blob/develop/main.nf#L2-L6) to see the list of currently available parameters/flags and their default values if you don't specify any.
+
+### Running nextflow using an EC2
+
+1. For an ec2 instance with Linux and docker, see here for installing Java 11: [How do I install a software package from the Extras Library on an EC2 instance running Amazon Linux 2?](https://aws.amazon.com/premiumsupport/knowledge-center/ec2-install-extras-library-software/)
+
+1. Install nextflow by following instructions here: [Get started — Nextflow](https://www.nextflow.io/docs/latest/getstarted.html#get-started)
+
+- Update PATH to include directory where your nextflow executable is
+
+1. Make sure to set any nextflow secrets using the Nextflow Cli: [Secrets — Nextflow](https://www.nextflow.io/docs/latest/secrets.html#command-line)
+
+- You will need to set a SYNAPSE_AUTH_TOKEN secret for running the nextflow genie repo by doing nextflow secrets set SYNAPSE_AUTH_TOKEN “INSERT YOUR SYNAPSE TOKEN HERE”
+
+1. Make any changes
+
+1. Run the pipeline
+
+```bash
+nextflow main.nf
+```
+
+Note: you can also chose what version of nextflow to run with using:
+
+```bash
+NXF_VER=<nextflow_version> nextflow main.nf
+```

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ This workflow takes care of transferring files to and from Synapse. Hence, it re
 
 ### Commands
 
-You can visit [parameters](https://github.com/Sage-Bionetworks/genie-bpc-pipeline/blob/develop/main.nf#L2-L6) to see the list of currently available parameters/flags and their default values if you don't specify any.
+You can visit [parameters](https://github.com/Sage-Bionetworks/genie-bpc-pipeline/blob/develop/main.nf#L2-L11) to see the list of currently available parameters/flags and their default values if you don't specify any.
 
 ### Running nextflow using an EC2
 

--- a/main.nf
+++ b/main.nf
@@ -1,6 +1,11 @@
 #!/usr/bin/env nextflow
 
 params.cohort = 'NSCLC'
+/* 
+Note: For multi-word strings like in the param comment here, everywhere that calls $comment as an argument
+needed to be enclosed with double quotes so that nextflow interprets it as an entire string and 
+not separate command line arguments 
+*/
 params.comment = 'NSCLC public release update'
 // testing or production pipeline
 params.production = false

--- a/main.nf
+++ b/main.nf
@@ -157,13 +157,13 @@ process updateDataTable {
    if (params.production) {
       """
       cd /root/scripts/
-      python update_data_table.py -p /root/scripts/config.json -m $comment primary
+      python update_data_table.py -p /root/scripts/config.json -m "$comment" primary
       """
    }
    else {
       """
       cd /root/scripts/
-      python update_data_table.py -p /root/scripts/config.json -m $comment -d True primary
+      python update_data_table.py -p /root/scripts/config.json -m "$comment" primary -d
       """
    }
 }
@@ -192,7 +192,7 @@ process updateDateTrackingTable {
    if (params.production) {
       """
       cd /usr/local/src/myscripts/
-      Rscript update_date_tracking_table.R -c $cohort -d `date +'%Y-%m-%d'` -s $comment
+      Rscript update_date_tracking_table.R -c $cohort -d `date +'%Y-%m-%d'` -s "$comment"
       """
    }
    else {
@@ -330,7 +330,7 @@ process updateCaseCountTable {
    if (params.production) {
       """
       cd /usr/local/src/myscripts/
-      Rscript update_case_count_table.R -s -c $comment
+      Rscript update_case_count_table.R -s -c "$comment"
       """
    }
    else {

--- a/main.nf
+++ b/main.nf
@@ -163,7 +163,7 @@ process updateDataTable {
    else {
       """
       cd /root/scripts/
-      python update_data_table.py -p /root/scripts/config.json -m $comment primary -d
+      python update_data_table.py -p /root/scripts/config.json -m $comment -d True primary
       """
    }
 }

--- a/main.nf
+++ b/main.nf
@@ -2,6 +2,8 @@
 
 params.cohort = 'NSCLC'
 params.comment = 'NSCLC public release update'
+// testing or production pipeline
+params.production = false
 
 // Check if cohort is part of allowed cohort list
 def allowed_cohorts = ["BLADDER", "BrCa", "CRC", "NSCLC", "PANC", "Prostate", "CRC2", "NSCLC2", "MELANOMA", "OVARIAN", "ESOPHAGO", "RENAL"]
@@ -18,6 +20,7 @@ process quacUploadReportError {
 
    container 'sagebionetworks/genie-bpc-quac'
    secret 'SYNAPSE_AUTH_TOKEN'
+   debug true
 
    input:
    // val previous from outCheckCohortCode
@@ -42,6 +45,7 @@ process quacUploadReportWarning {
 
    container 'sagebionetworks/genie-bpc-quac'
    secret 'SYNAPSE_AUTH_TOKEN'
+   debug true
 
    input:
    val previous from outUploadReportError
@@ -51,10 +55,18 @@ process quacUploadReportWarning {
    stdout into outUploadReportWarning
 
    script:
-   """
-   cd /usr/local/src/myscripts/
-   Rscript genie-bpc-quac.R -c $cohort -s all -r upload -l warning -u -v
-   """
+   if (params.production) {
+      """
+      cd /usr/local/src/myscripts/
+      Rscript genie-bpc-quac.R -c $cohort -s all -r upload -l warning -u -v
+      """
+   } 
+   else {
+      """
+      cd /usr/local/src/myscripts/
+      Rscript genie-bpc-quac.R -c $cohort -s all -r upload -l warning -v
+      """
+   }
 }
 
 outUploadReportWarning.view()
@@ -66,6 +78,7 @@ process mergeAndUncodeRcaUploads {
 
    container 'sagebionetworks/genie-bpc-pipeline-uploads'
    secret 'SYNAPSE_AUTH_TOKEN'
+   debug true
 
    input:
    val previous from outUploadReportWarning
@@ -75,10 +88,18 @@ process mergeAndUncodeRcaUploads {
    stdout into outMergeAndUncodeRcaUploads
 
    script:
-   """
-   cd /usr/local/src/myscripts/
-   Rscript merge_and_uncode_rca_uploads.R -c $cohort -u -v
-   """
+   if (params.production) {
+      """
+      cd /usr/local/src/myscripts/
+      Rscript merge_and_uncode_rca_uploads.R -c $cohort -u -v
+      """
+   }
+   else {
+      """
+      cd /usr/local/src/myscripts/
+      Rscript merge_and_uncode_rca_uploads.R -c $cohort -v
+      """
+   }
 }
 
 outMergeAndUncodeRcaUploads.view()
@@ -90,6 +111,7 @@ process tmpRemovePatientsFromMerged {
 
    container 'sagebionetworks/genie-bpc-pipeline-uploads'
    secret 'SYNAPSE_AUTH_TOKEN'
+   debug true
 
    input:
    val previous from outMergeAndUncodeRcaUploads
@@ -99,10 +121,18 @@ process tmpRemovePatientsFromMerged {
    stdout into outTmpRemovePatientsFromMerged
 
    script:
-   """
-   cd /usr/local/src/myscripts/
-   Rscript remove_patients_from_merged.R -c $cohort -v
-   """
+   if (params.production) {
+      """
+      cd /usr/local/src/myscripts/
+      Rscript remove_patients_from_merged.R -c $cohort -v
+      """
+   }
+   else {
+      """
+      cd /usr/local/src/myscripts/
+      Rscript remove_patients_from_merged.R -c $cohort -v -o NA
+      """
+   }
 }
 
 outTmpRemovePatientsFromMerged.view()
@@ -114,6 +144,7 @@ process updateDataTable {
 
    container 'sagebionetworks/genie-bpc-pipeline-table-updates'
    secret 'SYNAPSE_AUTH_TOKEN'
+   debug true
 
    input:
    val previous from outTmpRemovePatientsFromMerged
@@ -123,10 +154,18 @@ process updateDataTable {
    stdout into outUpdateDataTable
 
    script:
-   """
-   cd /root/scripts/
-   python update_data_table.py -p /root/scripts/config.json -m $comment primary
-   """
+   if (params.production) {
+      """
+      cd /root/scripts/
+      python update_data_table.py -p /root/scripts/config.json -m $comment primary
+      """
+   }
+   else {
+      """
+      cd /root/scripts/
+      python update_data_table.py -p /root/scripts/config.json -m $comment primary -d
+      """
+   }
 }
 
 outUpdateDataTable.view()
@@ -139,6 +178,7 @@ process updateDateTrackingTable {
 
    container 'sagebionetworks/genie-bpc-pipeline-references'
    secret 'SYNAPSE_AUTH_TOKEN'
+   debug true
 
    input:
    val previous from outUpdateDataTable
@@ -149,10 +189,18 @@ process updateDateTrackingTable {
    stdout into outUpdateDateTrackingTable
 
    script:
-   """
-   cd /usr/local/src/myscripts/
-   Rscript update_date_tracking_table.R -c $cohort -d `date +'%Y-%m-%d'` -s $comment
-   """
+   if (params.production) {
+      """
+      cd /usr/local/src/myscripts/
+      Rscript update_date_tracking_table.R -c $cohort -d `date +'%Y-%m-%d'` -s $comment
+      """
+   }
+   else {
+      """
+      cd /usr/local/src/myscripts/
+      Rscript update_date_tracking_table.R -c $cohort -d `date +'%Y-%m-%d'`
+      """
+   }
 }
 
 outUpdateDateTrackingTable.view()
@@ -165,6 +213,7 @@ process quacTableReport {
 
    container 'sagebionetworks/genie-bpc-quac'
    secret 'SYNAPSE_AUTH_TOKEN'
+   debug true
 
    input:
    val previous from outUpdateDateTrackingTable
@@ -174,11 +223,20 @@ process quacTableReport {
    stdout into outTableReport
 
    script:
-   """
-   cd /usr/local/src/myscripts/
-   Rscript genie-bpc-quac.R -c $cohort -s all -r table -l error -u -v
-   Rscript genie-bpc-quac.R -c $cohort -s all -r table -l warning -u -v
-   """
+   if (params.production) {
+      """
+      cd /usr/local/src/myscripts/
+      Rscript genie-bpc-quac.R -c $cohort -s all -r table -l error -u -v
+      Rscript genie-bpc-quac.R -c $cohort -s all -r table -l warning -u -v
+      """
+   }
+   else {
+      """
+      cd /usr/local/src/myscripts/
+      Rscript genie-bpc-quac.R -c $cohort -s all -r table -l error -v
+      Rscript genie-bpc-quac.R -c $cohort -s all -r table -l warning -v
+      """
+   }
 }
 
 outTableReport.view()
@@ -190,6 +248,7 @@ process quacComparisonReport {
 
    container 'sagebionetworks/genie-bpc-quac'
    secret 'SYNAPSE_AUTH_TOKEN'
+   debug true
 
    input:
    val previous from outTableReport
@@ -199,11 +258,20 @@ process quacComparisonReport {
    stdout into outComparisonReport
 
    script:
-   """
-   cd /usr/local/src/myscripts/
-   Rscript genie-bpc-quac.R -c $cohort -s all -r comparison -l error -u -v
-   Rscript genie-bpc-quac.R -c $cohort -s all -r comparison -l warning -u -v
-   """
+   if (params.production) {
+      """
+      cd /usr/local/src/myscripts/
+      Rscript genie-bpc-quac.R -c $cohort -s all -r comparison -l error -u -v
+      Rscript genie-bpc-quac.R -c $cohort -s all -r comparison -l warning -u -v
+      """
+   }
+   else {
+      """
+      cd /usr/local/src/myscripts/
+      Rscript genie-bpc-quac.R -c $cohort -s all -r comparison -l error -v
+      Rscript genie-bpc-quac.R -c $cohort -s all -r comparison -l warning -v
+      """
+   }
 }
 
 outComparisonReport.view()
@@ -215,6 +283,7 @@ process maskingReport {
 
    container 'sagebionetworks/genie-bpc-pipeline-masking'
    secret 'SYNAPSE_AUTH_TOKEN'
+   debug true
 
    input:
    val previous from outComparisonReport
@@ -224,10 +293,18 @@ process maskingReport {
    stdout into outMaskingReport
 
    script:
-   """
-   cd /usr/local/src/myscripts/
-   Rscript workflow_unmasked_drugs.R -c $cohort -d `date +'%Y-%m-%d'` -s
-   """
+   if (params.production) {
+      """
+      cd /usr/local/src/myscripts/
+      Rscript workflow_unmasked_drugs.R -c $cohort -d `date +'%Y-%m-%d'` -s
+      """
+   }
+   else {
+      """
+      cd /usr/local/src/myscripts/
+      Rscript workflow_unmasked_drugs.R -c $cohort -d `date +'%Y-%m-%d'`
+      """
+   }
 }
 
 outMaskingReport.view()
@@ -240,6 +317,7 @@ process updateCaseCountTable {
 
    container 'sagebionetworks/genie-bpc-pipeline-case-selection'
    secret 'SYNAPSE_AUTH_TOKEN'
+   debug true
 
    input:
    val previous from outMaskingReport
@@ -249,10 +327,18 @@ process updateCaseCountTable {
    stdout into outCaseCount
 
    script:
-   """
-   cd /usr/local/src/myscripts/
-   Rscript update_case_count_table.R -s -c $comment
-   """
+   if (params.production) {
+      """
+      cd /usr/local/src/myscripts/
+      Rscript update_case_count_table.R -s -c $comment
+      """
+   }
+   else {
+      """
+      cd /usr/local/src/myscripts/
+      Rscript update_case_count_table.R
+      """
+   }
 }
 
 outCaseCount.view()

--- a/scripts/table_updates/README.md
+++ b/scripts/table_updates/README.md
@@ -3,6 +3,9 @@ BPC Table Update
 
 Installation and Setup
 ----------------------
+### Python version
+Make sure you have Python 3.8 installed
+
 ### Install the required packages
     (sudo) pip install -r requirements.txt
 


### PR DESCRIPTION
**Purpose:** This allows the genie bpc pipeline to be run on nextflow in production or development mode with the addition of the following:

- `debug` mode in all processes in main.nf
- `production` parameter for use in all processes in main.nf (with the exception of `quacUploadReportError` which doesn't upload to synapse in general) which for right now, it indicates whether we upload/update anything in Synapse (prod) or not (develop)

This also adds nextflow configuration and development instructions to the README and fixes a bug with $comment in the `main.nf`