### PR TITLE
[GEN-793] Remove header1 in NSCLC and CRC

### DIFF
--- a/scripts/uploads/config.yaml
+++ b/scripts/uploads/config.yaml
@@ -28,7 +28,7 @@ upload:
   CRC:
     DFCI:
       data1: syn25961098
-      header1: syn25961099
+      #header1: syn25961099
     MSK:
       data1: syn25953196
     VICC:
@@ -36,7 +36,7 @@ upload:
   NSCLC:
     DFCI:
       data1: syn25582436
-      header1: syn25582427
+      #header1: syn25582427
     MSK:
       data1: syn25557012
     UHN:


### PR DESCRIPTION
DFCI no longer needs the header file