### PR TITLE
GEN-1179 remove custom yesno mapping

### DIFF
--- a/scripts/uploads/config.yaml
+++ b/scripts/uploads/config.yaml
@@ -179,9 +179,6 @@ mapping:
     6: "Form Removed"
     7: "Form Locked"
     8: "Form Signed"
-  yesno_rca:
-    0: "No"
-    1: "Yes"
   instrument:
     ca_directed_drugs: "Ca Directed Drugs"
     cancer_diagnosis: "Cancer Diagnosis"

--- a/scripts/uploads/merge_and_uncode_rca_uploads.R
+++ b/scripts/uploads/merge_and_uncode_rca_uploads.R
@@ -480,16 +480,6 @@ format_rca <- function(x, dd) {
     x[,col_dt] <- lapply(x[,col_dt], convert_string_to_date, format = "%Y-%m-%d")
   }
   
-  # modify boolean values values
-  mapping_yesno <- data.frame(codes = names(config$mapping$yesno_rca),
-                              values = as.character(config$mapping$yesno_rca),
-                              stringsAsFactors = F)
-  idx_ind <- dd$`Variable / Field Name`[which(dd$`Field Type` == "yesno")]
-  #x[,idx_ind] <- lapply(x[,idx_ind, drop = F], FUN = function(x) {return(uncode_data_column(x, mapping = mapping_yesno))})
-  for (idx in idx_ind) {
-    x[,idx] <- as.character(unlist(uncode_data_column(x[,idx], mapping = mapping_yesno)))
-  }
-  
   # modify instrument
   mapping_instrument <- data.frame(codes = names(config$mapping$instrument),
                                    values = as.character(config$mapping$instrument),


### PR DESCRIPTION
Issue:

Variable field type update (yesno -> dropdown) in later version of data dictionary resulted in mapping to NA 

Solution:
Add yesno variables to the GRS and remove the custom mapping in the code. Use GRS as the universal key to map