### PR TITLE
[GEN-1448] Fix bug that causes blank Curation and QA and Patient Characteristics tables

### DIFF
--- a/scripts/table_updates/utilities.py
+++ b/scripts/table_updates/utilities.py
@@ -69,7 +69,7 @@ def get_data(syn, label_data_id, cohort):
     Returns:
         Dataframe: label data
     """
-    na_values = [" ", "#N/A", "#N/A N/A", "#NA", "-1.#IND", "-1.#QNAN", "-NaN", "-nan", "1.#IND", "1.#QNAN", "<NA>", "N/A", "NA", "NULL", "NaN", "n/a", "nan", "null"]
+    na_values = ["", "#N/A", "#N/A N/A", "#NA", "-1.#IND", "-1.#QNAN", "-NaN", "-nan", "1.#IND", "1.#QNAN", "<NA>", "N/A", "NA", "NULL", "NaN", "n/a", "nan", "null"]
     label_data = pandas.read_csv(syn.get(label_data_id).path, low_memory=False, na_values=na_values, keep_default_na=False)
     label_data['cohort'] = cohort
     return(label_data)


### PR DESCRIPTION
**Purpose:** See [JIRA Ticket](https://sagebionetworks.jira.com/browse/GEN-1448) for more background info but this adds back "" as a default string to NA value when reading csvs. The `get_data` function wasn't reading in blank values as NAs so later on in the code when we filter using `isnull()`, we wouldn't get any data showing up.

**Testing:**
Tested on pipeline with `""` added and `" "` removed, and got back non-blank data for the above tables