### PR TITLE
[GEN-1456] downgrade synapseclient

### DIFF
--- a/scripts/table_updates/requirements.txt
+++ b/scripts/table_updates/requirements.txt
@@ -1,1 +1,1 @@
-synapseclient[pandas] == 4.3.0
+synapseclient[pandas] == 2.7.2


### PR DESCRIPTION
**Purpose:** See [JIRA ticket](https://sagebionetworks.jira.com/browse/GEN-1456) for the background info. `synapseclient` is downgraded to `2.7.2` thus downgrading `pandas` to <2.0 so there is no clash in the code. 

**Testing:** Ran update_data_tables.py locally and synapse tables have expected results