### PR TITLE
[GEN-1458] Refactor custom_fix function to pull from main genie release

### DIFF
--- a/scripts/table_updates/config.json
+++ b/scripts/table_updates/config.json
@@ -18,5 +18,8 @@
         "NSCLC2": "syn51318736",
         "CRC2": "syn52943210",
         "RENAL": "syn59474249"
-    }
+    },
+    "main_genie_release_version": "16.6-consortium",
+    "main_genie_data_release_files": "syn16804261",
+    "main_genie_sample_mapping_table": "syn7434273"
 }

--- a/scripts/table_updates/update_data_table.py
+++ b/scripts/table_updates/update_data_table.py
@@ -24,68 +24,115 @@ import numpy
 
 from utilities import *
 
-TABLE_INFO = {"primary": ('syn23285911',"table_type='data'"),
-              "irr": ('syn21446696',"table_type='data' and double_curated is true")}
+TABLE_INFO = {
+    "primary": ("syn23285911", "table_type='data'"),
+    "irr": ("syn21446696", "table_type='data' and double_curated is true"),
+}
+
+
+def get_main_genie_clinical_sample_file(
+    syn: synapseclient.Synapse, release: str, release_files_table_synid: str
+) -> pandas.DataFrame:
+    """This retrieves the main genie clinical sample file from consortium release
+
+    Args:
+        release (str): release version to pull from for main genie
+        release_files_table_synid (str): synapse id of the data relese files table
+        from main genie
+
+    Returns:
+        pandas.DataFrame: the read in clinical file as dataframe
+    """
+    release_files = syn.tableQuery(
+        f"SELECT * FROM {release_files_table_synid}"
+    ).asDataFrame()
+    #assert_frame_equal(release_files, release_files)
+    clinical_link_synid = release_files[
+        (release_files["release"] == release)
+        & (release_files["name"] == "data_clinical_sample.txt")
+    ]["fileSynId"].values[0]
+    clinical_link_ent = syn.get(clinical_link_synid)
+    clinical_ent = syn.get(
+        clinical_link_ent["linksTo"]["targetId"],
+        version=clinical_link_ent["linksTo"]["targetVersionNumber"],
+    )
+    clinical_df = pandas.read_csv(clinical_ent.path, sep="\t", skiprows=4)
+    assert (
+        not clinical_df.empty
+    ), f"Clinical file pulled from {clinical_link_synid} link is empty."
+    assert set(["SAMPLE_ID", "SEQ_YEAR"]) < set(clinical_df.columns), (
+        f"Clinical file pulled from {clinical_link_synid} link is missing an expected column. "
+        "Expected columns: ['SAMPLE_ID', 'SEQ_YEAR']"
+    )
+    return clinical_df[["SAMPLE_ID", "SEQ_YEAR"]]
+
 
 def _store_data(syn, table_id, label_data, table_type, logger, dry_run):
     table_schema = syn.get(table_id)
     logger.info(f"Updating table: {table_schema.name} {table_id}")
     form_label = table_schema.form_label[0]
     table_columns = syn.getColumns(table_schema.columnIds)
-    table_columns = [col['name'] for col in list(table_columns)]
-    table_columns = list(set(table_columns) & set(label_data.columns)) # variable in dd but not in data
+    table_columns = [col["name"] for col in list(table_columns)]
+    table_columns = list(
+        set(table_columns) & set(label_data.columns)
+    )  # variable in dd but not in data
     table_columns.append("redcap_repeat_instrument")
     temp_data = label_data[table_columns]
     if form_label == "non-repeating":
         temp_data = temp_data[temp_data.redcap_repeat_instrument.isnull()]
     else:
-        temp_data = temp_data[temp_data.redcap_repeat_instrument==form_label]
-    temp_data.drop(columns="redcap_repeat_instrument",inplace=True)
+        temp_data = temp_data[temp_data.redcap_repeat_instrument == form_label]
+    temp_data.drop(columns="redcap_repeat_instrument", inplace=True)
     # remove rows with no data
-    cols_to_skip =['cohort','record_id','redcap_data_access_group']
+    cols_to_skip = ["cohort", "record_id", "redcap_data_access_group"]
     if "redcap_repeat_instance" in table_columns:
-        if table_schema.form in [['prissmm_pathology'],['ca_directed_radtx'],['cancer_diagnosis']]:
-            cols_to_skip = ['cohort','record_id','redcap_repeat_instance']
+        if table_schema.form in [
+            ["prissmm_pathology"],
+            ["ca_directed_radtx"],
+            ["cancer_diagnosis"],
+        ]:
+            cols_to_skip = ["cohort", "record_id", "redcap_repeat_instance"]
         else:
             cols_to_skip.append("redcap_repeat_instance")
-    rows_to_drop = temp_data.index[temp_data.apply(lambda row: check_empty_row(row,cols_to_skip),axis=1)]
-    temp_data.drop(index=rows_to_drop,inplace=True)
+    rows_to_drop = temp_data.index[
+        temp_data.apply(lambda row: check_empty_row(row, cols_to_skip), axis=1)
+    ]
+    temp_data.drop(index=rows_to_drop, inplace=True)
     # remove .0 from all columns
     temp_data = temp_data.applymap(lambda x: float_to_int(x))
     # update table
     table_query = syn.tableQuery("SELECT * from %s" % table_id)
-    if table_type=='irr':
+    if table_type == "irr":
         # check for exsiting id to update for new data only
-        existing_records = list(set(table_query.asDataFrame()['record_id']))
-        temp_data = temp_data[~temp_data['record_id'].isin(existing_records)]
+        existing_records = list(set(table_query.asDataFrame()["record_id"]))
+        temp_data = temp_data[~temp_data["record_id"].isin(existing_records)]
     if not dry_run:
-        if table_type=='primary':
-            table = syn.delete(table_query.asRowSet()) # wipe the table
+        if table_type == "primary":
+            table = syn.delete(table_query.asRowSet())  # wipe the table
         table = syn.store(Table(table_schema, temp_data))
     else:
-        temp_data.to_csv(table_id+"_temp.csv")
+        temp_data.to_csv(table_id + "_temp.csv")
+
 
 def store_data(syn, master_table, label_data, table_type, logger, dry_run):
     logger.info("Updating data for %s tables..." % table_type)
-    for table_id in master_table['id']:
+    for table_id in master_table["id"]:
         _store_data(syn, table_id, label_data, table_type, logger, dry_run)
 
+
 def get_phi_cutoff(unit):
-    switcher = {
-        "day": math.floor(89*365),
-        "month": math.floor(89*12),
-        "year": 89
-    }
-    return(switcher.get(unit, "Invalid unit"))
+    switcher = {"day": math.floor(89 * 365), "month": math.floor(89 * 12), "year": 89}
+    return switcher.get(unit, "Invalid unit")
+
 
 def _to_redact_interval(df_col, unit):
     """Determines interval values that are >89 that need to be redacted
     Returns bool because BIRTH_YEAR needs to be redacted as well based
     on the results
-    
+
     Args:
         df_col: Dataframe column/pandas.Series of an interval column
-    
+
     Returns:
         tuple: pandas.Series: to redact boolean vector
     """
@@ -93,39 +140,45 @@ def _to_redact_interval(df_col, unit):
     # must be redacted
     contain_greaterthan = df_col.astype(str).str.contains(">", na=False)
     # Add in errors='coerce' to turn strings into NaN
-    col_int = pandas.to_numeric(df_col, errors='coerce')
+    col_int = pandas.to_numeric(df_col, errors="coerce")
     to_redact = (col_int > get_phi_cutoff(unit)) | contain_greaterthan
     return to_redact
 
+
 def _to_redact_birth_year(df_col_birth_year, df_col_dt_compare, df_col_vital_status):
-    """Determines age > 89 in days as of the date to compare and vital status is alive 
+    """Determines age > 89 in days as of the date to compare and vital status is alive
     that need to be redacted. If data to compare is NA, default to today.
-    
+
     Args:
         df_col_birth_year: Dataframe column/pandas.Series of a year column
         df_col_dt_compare: Dataframe column/pandas.Series of a date column
         df_col_vital_status: Dataframe column/pandas.Series of a boolean column
-    
+
     Returns:
         tuple: pandas.core.indexes: to redact index in Dataframe
     """
-    if len(df_col_dt_compare)==0:
+    if len(df_col_dt_compare) == 0:
         df_col_dt_compare = datetime.date.today()
     else:
-        df_col_dt_compare = df_col_dt_compare.fillna(datetime.datetime.now().strftime("%Y-%m-%d"))  
-        df_col_dt_compare = df_col_dt_compare.apply(lambda x: datetime.datetime.strptime(str(x),"%Y-%m-%d").date())
-    df_col_birth_year = df_col_birth_year.fillna(1900) # arbitrary year > 89 yrs old
+        df_col_dt_compare = df_col_dt_compare.fillna(
+            datetime.datetime.now().strftime("%Y-%m-%d")
+        )
+        df_col_dt_compare = df_col_dt_compare.apply(
+            lambda x: datetime.datetime.strptime(str(x), "%Y-%m-%d").date()
+        )
+    df_col_birth_year = df_col_birth_year.fillna(1900)  # arbitrary year > 89 yrs old
     df_col_birth_date = df_col_birth_year.apply(lambda x: datetime.date(int(x), 1, 1))
     dates_diff = df_col_dt_compare - df_col_birth_date
     dates_phi_bool = dates_diff.map(lambda x: x.days > get_phi_cutoff("day"))
-    vital_status_bool = df_col_vital_status == 'No'
+    vital_status_bool = df_col_vital_status == "No"
     to_redact = dates_phi_bool & vital_status_bool
     return to_redact[to_redact].index
 
+
 def _to_redact_seq_age(df_col_seq_age, df_col_vital_status):
     """
-    Determines age of sequencing > 89 in days and vital status is dead 
-    that need to be redacted. 
+    Determines age of sequencing > 89 in days and vital status is dead
+    that need to be redacted.
     Args:
         df_col_seq_age: Dataframe column/pandas.Series of anx interval column
         df_col_vital_status: Dataframe column/pandas.Series of a boolean column
@@ -133,142 +186,217 @@ def _to_redact_seq_age(df_col_seq_age, df_col_vital_status):
         tuple: pandas.core.indexes: to redact index in Dataframe
     """
     contain_greaterthan = df_col_seq_age.astype(str).str.contains(">", na=False)
-    col_int = pandas.to_numeric(df_col_seq_age, errors='coerce')
+    col_int = pandas.to_numeric(df_col_seq_age, errors="coerce")
     col_seq_age = (col_int > get_phi_cutoff("day")) | contain_greaterthan
-    vital_status_bool = df_col_vital_status == 'Yes'
+    vital_status_bool = df_col_vital_status == "Yes"
     to_redact = col_seq_age & vital_status_bool
     return to_redact[to_redact].index
 
+
 def _redact_table(df, interval_cols_info):
     record_to_redact = list()
-    interval_list = list(set(interval_cols_info['variable']).intersection(set(df.columns.values.tolist())))
+    interval_list = list(
+        set(interval_cols_info["variable"]).intersection(
+            set(df.columns.values.tolist())
+        )
+    )
     if len(interval_list) != 0:
         for col in interval_list:
-            unit = interval_cols_info.loc[interval_cols_info['variable']==col,'unit'].values[0]
-            to_redact = _to_redact_interval(df[col],unit)
-            index_to_redact = to_redact.index[to_redact==True]
+            unit = interval_cols_info.loc[
+                interval_cols_info["variable"] == col, "unit"
+            ].values[0]
+            to_redact = _to_redact_interval(df[col], unit)
+            index_to_redact = to_redact.index[to_redact == True]
             df.loc[index_to_redact, col] = ""
             df[col] = df[col].map(float_to_int)
-            record_to_redact = record_to_redact+[df['record_id'][x] for x in index_to_redact]
+            record_to_redact = record_to_redact + [
+                df["record_id"][x] for x in index_to_redact
+            ]
     return df, record_to_redact
 
+
 def update_redact_table(syn, redacted_table_info, full_data_table_info, logger):
-    interval_cols_info = download_synapse_table(syn,'syn23281483','')
+    interval_cols_info = download_synapse_table(syn, "syn23281483", "")
     # Create new master table
-    master_table = redacted_table_info.merge(full_data_table_info, on='name', suffixes=('_redacted','_full'))
+    master_table = redacted_table_info.merge(
+        full_data_table_info, on="name", suffixes=("_redacted", "_full")
+    )
     # Get the tables for checking
-    curation_table_id = master_table.loc[master_table['name']=="Curation and QA",'id_full'].values[0]
-    patient_table_id = master_table.loc[master_table['name']=="Patient Characteristics",'id_full'].values[0]
-    sample_table_id = master_table.loc[master_table['name']=="Cancer Panel Test",'id_full'].values[0]
-    curation_info = syn.tableQuery('SELECT record_id, curation_dt FROM %s' % curation_table_id).asDataFrame()
-    patient_info = syn.tableQuery('SELECT record_id, birth_year, hybrid_death_ind FROM %s' % patient_table_id).asDataFrame()
-    sample_info = syn.tableQuery('SELECT record_id, cpt_genie_sample_id, age_at_seq_report FROM %s' % sample_table_id).asDataFrame()
-    patient_curation_info = patient_info.merge(curation_info, how='left', on='record_id')
-    clinical_info = patient_info.merge(sample_info, how='right', on='record_id')
+    curation_table_id = master_table.loc[
+        master_table["name"] == "Curation and QA", "id_full"
+    ].values[0]
+    patient_table_id = master_table.loc[
+        master_table["name"] == "Patient Characteristics", "id_full"
+    ].values[0]
+    sample_table_id = master_table.loc[
+        master_table["name"] == "Cancer Panel Test", "id_full"
+    ].values[0]
+    curation_info = syn.tableQuery(
+        "SELECT record_id, curation_dt FROM %s" % curation_table_id
+    ).asDataFrame()
+    patient_info = syn.tableQuery(
+        "SELECT record_id, birth_year, hybrid_death_ind FROM %s" % patient_table_id
+    ).asDataFrame()
+    sample_info = syn.tableQuery(
+        "SELECT record_id, cpt_genie_sample_id, age_at_seq_report FROM %s"
+        % sample_table_id
+    ).asDataFrame()
+    patient_curation_info = patient_info.merge(
+        curation_info, how="left", on="record_id"
+    )
+    clinical_info = patient_info.merge(sample_info, how="right", on="record_id")
     # Check birth year vs curation date with vital status = alive
-    birth_year_flag = _to_redact_birth_year(patient_curation_info['birth_year'], patient_curation_info['curation_dt'], patient_curation_info['hybrid_death_ind'])
-    record_to_redact = patient_curation_info.loc[birth_year_flag, 'record_id'].values.tolist()
+    birth_year_flag = _to_redact_birth_year(
+        patient_curation_info["birth_year"],
+        patient_curation_info["curation_dt"],
+        patient_curation_info["hybrid_death_ind"],
+    )
+    record_to_redact = patient_curation_info.loc[
+        birth_year_flag, "record_id"
+    ].values.tolist()
     # Check seq age with vital status = deceased
-    seq_age_flag = _to_redact_seq_age(clinical_info['age_at_seq_report'], clinical_info['hybrid_death_ind'])
-    record_to_redact = record_to_redact+clinical_info.loc[seq_age_flag, 'record_id'].values.tolist()
+    seq_age_flag = _to_redact_seq_age(
+        clinical_info["age_at_seq_report"], clinical_info["hybrid_death_ind"]
+    )
+    record_to_redact = (
+        record_to_redact + clinical_info.loc[seq_age_flag, "record_id"].values.tolist()
+    )
     # Check interval fields and store the data table
-    for _,row in master_table.iterrows():
-        if row['name'] != 'Patient Characteristics':
-            table_id = row['id_full']
-            df = syn.tableQuery('SELECT * FROM %s' % table_id).asDataFrame()
+    for _, row in master_table.iterrows():
+        if row["name"] != "Patient Characteristics":
+            table_id = row["id_full"]
+            df = syn.tableQuery("SELECT * FROM %s" % table_id).asDataFrame()
             new_df, new_record_to_redact = _redact_table(df, interval_cols_info)
             new_df.reset_index(drop=True, inplace=True)
-            record_to_redact = record_to_redact+new_record_to_redact
-            table_schema = syn.get(row['id_redacted'])
+            record_to_redact = record_to_redact + new_record_to_redact
+            table_schema = syn.get(row["id_redacted"])
             logger.info("Updating table: %s" % table_schema.name)
-            table_query = syn.tableQuery("SELECT * from %s" % row['id_redacted'])
-            table = syn.delete(table_query.asRowSet()) # wipe the table
+            table_query = syn.tableQuery("SELECT * from %s" % row["id_redacted"])
+            table = syn.delete(table_query.asRowSet())  # wipe the table
             table = syn.store(Table(table_schema, new_df))
     # Modify patient table
-    df = syn.tableQuery('SELECT * FROM %s' % patient_table_id).asDataFrame()
+    df = syn.tableQuery("SELECT * FROM %s" % patient_table_id).asDataFrame()
     new_df, new_record_to_redact = _redact_table(df, interval_cols_info)
     new_df.reset_index(drop=True, inplace=True)
-    record_to_redact = record_to_redact+new_record_to_redact
+    record_to_redact = record_to_redact + new_record_to_redact
     # Update the patient table according to redacted records
     logger.info("Updating patient table...")
     final_record = list(set(record_to_redact))
-    new_df.loc[new_df['record_id'].isin(final_record), 'redacted'] = 'Yes'
-    new_df.loc[new_df['record_id'].isin(final_record), 'birth_year'] = ''
-    new_df['birth_year'] = new_df['birth_year'].map(float_to_int)
-    new_df['redacted'] = new_df['redacted'].fillna(value='No')
-    redacted_patient_id = master_table.loc[master_table['name']=="Patient Characteristics",'id_redacted'].values[0]
+    new_df.loc[new_df["record_id"].isin(final_record), "redacted"] = "Yes"
+    new_df.loc[new_df["record_id"].isin(final_record), "birth_year"] = ""
+    new_df["birth_year"] = new_df["birth_year"].map(float_to_int)
+    new_df["redacted"] = new_df["redacted"].fillna(value="No")
+    redacted_patient_id = master_table.loc[
+        master_table["name"] == "Patient Characteristics", "id_redacted"
+    ].values[0]
     table_schema = syn.get(redacted_patient_id)
     table_query = syn.tableQuery("SELECT * from %s" % redacted_patient_id)
-    table = syn.delete(table_query.asRowSet()) # wipe the table
+    table = syn.delete(table_query.asRowSet())  # wipe the table
     table = syn.store(Table(table_schema, new_df))
     # Update redacted column in full data patient table
     logger.info("Updating redacted column in the internal table...")
-    full_pt_id = master_table.loc[master_table['name']=="Patient Characteristics",'id_full'].values[0]
+    full_pt_id = master_table.loc[
+        master_table["name"] == "Patient Characteristics", "id_full"
+    ].values[0]
     full_pt_schema = syn.get(full_pt_id)
-    pt_dat_query = syn.tableQuery('SELECT cohort, record_id FROM %s' % full_pt_id)
+    pt_dat_query = syn.tableQuery("SELECT cohort, record_id FROM %s" % full_pt_id)
     pt_dat = pt_dat_query.asDataFrame()
     pt_dat.index = pt_dat.index.map(str)
-    pt_dat['index'] = pt_dat.index
-    info_to_update = new_df[['cohort','record_id','redacted']]
-    result = pandas.merge(pt_dat,info_to_update, on=['cohort','record_id'])
-    result.index = result['index']
-    result = result[['redacted']]
+    pt_dat["index"] = pt_dat.index
+    info_to_update = new_df[["cohort", "record_id", "redacted"]]
+    result = pandas.merge(pt_dat, info_to_update, on=["cohort", "record_id"])
+    result.index = result["index"]
+    result = result[["redacted"]]
     syn.store(Table(full_pt_schema, result, etag=pt_dat_query.etag))
 
-def custom_fix(syn, master_table, logger):
+
+def custom_fix_for_cancer_panel_test_table(
+    syn: synapseclient.Synapse,
+    master_table: pandas.DataFrame,
+    logger: logging.Logger,
+    config: dict,
+) -> None:
+    """
+    This overwrites the cpt_seq_date column in the Cancer Panel Test
+    table in BPC with the SEQ_DATE column from the main genie clinical sample
+    file from a consortium release specified in the config.json
+
+    This also overwrites the cpt_sample_type column with the description
+    column from the main genie SAMPLE_TYPE_MAPPING table
+
+    Args:
+        syn (synapseclient.Synapse): synapse client connection
+        master_table (pandas.DataFrame): table of all of the primary BPC tables
+        logger (logging.Logger): logger object
+        config (dict): config read in
+    """
     logger.info("Custom fix in progress...")
     # Modify the cpt_seq_date table per request
-    cpt_table_id = master_table.loc[master_table['form_label']=="Cancer Panel Test",'id'].values[0]
+    cpt_table_id = master_table.loc[
+        master_table["form_label"] == "Cancer Panel Test", "id"
+    ].values[0]
     cpt_table_schema = syn.get(cpt_table_id)
-    cpt_dat_query = syn.tableQuery('SELECT cpt_genie_sample_id FROM %s' % cpt_table_id)
+    cpt_dat_query = syn.tableQuery("SELECT cpt_genie_sample_id FROM %s" % cpt_table_id)
     cpt_dat = cpt_dat_query.asDataFrame()
     cpt_dat.index = cpt_dat.index.map(str)
-    cpt_dat['index'] = cpt_dat.index
-    genie_sample_dat = syn.tableQuery('SELECT SAMPLE_ID, SEQ_YEAR FROM syn7517674').asDataFrame()
-    cpt_seq_dat = cpt_dat.merge(genie_sample_dat, how='left',left_on='cpt_genie_sample_id', right_on='SAMPLE_ID')
-    cpt_seq_dat.index = cpt_seq_dat['index']
-    cpt_seq_dat = cpt_seq_dat[['SEQ_YEAR']]
-    cpt_seq_dat.columns = ['cpt_seq_date']
-    cpt_seq_dat['cpt_seq_date'] = cpt_seq_dat['cpt_seq_date'].map(float_to_int)
+    cpt_dat["index"] = cpt_dat.index
+    # genie_sample_dat = syn.tableQuery('SELECT SAMPLE_ID, SEQ_YEAR FROM syn7517674').asDataFrame()
+    genie_sample_dat = get_main_genie_clinical_sample_file(
+        syn,
+        release=config["main_genie_release_version"],
+        release_files_table_synid=config["main_genie_data_release_files"],
+    )
+    cpt_seq_dat = cpt_dat.merge(
+        genie_sample_dat,
+        how="left",
+        left_on="cpt_genie_sample_id",
+        right_on="SAMPLE_ID",
+    )
+    cpt_seq_dat.index = cpt_seq_dat["index"]
+    cpt_seq_dat = cpt_seq_dat[["SEQ_YEAR"]]
+    cpt_seq_dat.columns = ["cpt_seq_date"]
+    cpt_seq_dat["cpt_seq_date"] = cpt_seq_dat["cpt_seq_date"].map(float_to_int)
     syn.store(Table(cpt_table_schema, cpt_seq_dat, etag=cpt_dat_query.etag))
     # Modify the cpt_sample_type -> map to text value
     cpt_table_schema = syn.get(cpt_table_id)
-    cpt_dat_query = syn.tableQuery('SELECT cpt_sample_type FROM %s WHERE cpt_sample_type in (1,2,3,4,5,6,7)' 
-                                   % cpt_table_id)
+    cpt_dat_query = syn.tableQuery(
+        "SELECT cpt_sample_type FROM %s WHERE cpt_sample_type in (1,2,3,4,5,6,7)"
+        % cpt_table_id
+    )
     cpt_dat = cpt_dat_query.asDataFrame()
-    cpt_dat['cpt_sample_type'] = pandas.to_numeric(cpt_dat['cpt_sample_type'])
-    sample_type_mapping = syn.tableQuery("SELECT * FROM syn7434273").asDataFrame()
-    sample_type_mapping_dict = sample_type_mapping.set_index('CODE').to_dict()['DESCRIPTION']
-    cpt_dat['cpt_sample_type'] = cpt_dat['cpt_sample_type'].map(sample_type_mapping_dict)
+    cpt_dat["cpt_sample_type"] = pandas.to_numeric(cpt_dat["cpt_sample_type"])
+    sample_type_mapping = syn.tableQuery(
+        f"SELECT * FROM {config['main_genie_sample_mapping_table']}"
+    ).asDataFrame()
+    sample_type_mapping_dict = sample_type_mapping.set_index("CODE").to_dict()[
+        "DESCRIPTION"
+    ]
+    cpt_dat["cpt_sample_type"] = cpt_dat["cpt_sample_type"].map(
+        sample_type_mapping_dict
+    )
     syn.store(Table(cpt_table_schema, cpt_dat, etag=cpt_dat_query.etag))
     logger.info("Completed")
 
+
 def main():
-    #add arguments
+    # add arguments
     parser = argparse.ArgumentParser(
-        description='Update data tables on Synapse for BPC databases')
-    parser.add_argument(
-        "table", 
-        type=str,
-        help='Specify table type to run',
-        choices=TABLE_INFO.keys())
-    parser.add_argument(
-        "-s", "--synapse_config",
-        default=synapseclient.client.CONFIG_FILE,
-        help="Synapse credentials file")
-    parser.add_argument(
-        "-p", "--project_config",
-        default="config.json",
-        help="Project config file")
-    parser.add_argument(
-        "-m","--message",
-        default="",
-        help = "Version comment")
-    parser.add_argument(
-        "-d", "--dry_run",
-        action="store_true",
-        help="dry run flag"
+        description="Update data tables on Synapse for BPC databases"
     )
+    parser.add_argument(
+        "table", type=str, help="Specify table type to run", choices=TABLE_INFO.keys()
+    )
+    parser.add_argument(
+        "-s",
+        "--synapse_config",
+        default=synapseclient.client.CONFIG_FILE,
+        help="Synapse credentials file",
+    )
+    parser.add_argument(
+        "-p", "--project_config", default="config.json", help="Project config file"
+    )
+    parser.add_argument("-m", "--message", default="", help="Version comment")
+    parser.add_argument("-d", "--dry_run", action="store_true", help="dry run flag")
 
     args = parser.parse_args()
     table_type = args.table
@@ -276,55 +404,59 @@ def main():
     project_config = args.project_config
     comment = args.message
     dry_run = args.dry_run
-    
-    #login to synapse
+
+    # login to synapse
     syn = synapse_login(synapse_config)
-    
-    #create logger
+
+    # create logger
     logger_name = "testing" if dry_run else "production"
     logger = setup_custom_logger(logger_name)
-    logger.info('Updating data tables on Synapse!')
+    logger.info("Updating data tables on Synapse!")
 
-    #read the project config file
+    # read the project config file
     with open(project_config) as config_file:
-        cohort_info = json.load(config_file)
+        config = json.load(config_file)
         logger.info("Read cohort information successful.")
-    
+
     # get master table
     # This is the internal tables with non redacted
     table_id, condition = list(TABLE_INFO[table_type])
     master_table = download_synapse_table(syn, table_id, condition)
     # This contains external tables with redacted
-    TABLE_INFO["redacted"] = ('syn21446696',"table_type='data' and double_curated is false")
+    TABLE_INFO["redacted"] = (
+        "syn21446696",
+        "table_type='data' and double_curated is false",
+    )
 
     # download data files
     # TODO: find the cohort that has new data
     # This is a mapping to all the intake data. e.g: ProstateBPCIntake_data
     # found here: https://www.synapse.org/Synapse:syn23286928
-    cohort_info_selected = cohort_info[table_type]
+    cohort_info_selected = config[table_type]
     cohort_data_list = []
     for cohort in cohort_info_selected:
-        df = get_data(syn, cohort_info_selected[cohort],cohort)
+        df = get_data(syn, cohort_info_selected[cohort], cohort)
         cohort_data_list.append(df)
     label_data = pandas.concat(cohort_data_list, axis=0, ignore_index=True)
-    label_data['redacted'] = numpy.nan
-    
+    label_data["redacted"] = numpy.nan
+
     # update data tables
     store_data(syn, master_table, label_data, table_type, logger, dry_run)
     if not dry_run:
-        custom_fix(syn, master_table, logger)
-        if table_type == 'primary':
-            table_id, condition = list(TABLE_INFO['redacted'])
+        custom_fix_for_cancer_panel_test_table(syn, master_table, logger, config)
+        if table_type == "primary":
+            table_id, condition = list(TABLE_INFO["redacted"])
             redacted_table_info = download_synapse_table(syn, table_id, condition)
             logger.info("Updating redacted tables...")
             update_redact_table(syn, redacted_table_info, master_table, logger)
             logger.info("Updating version for redacted tables")
-            for table_id in redacted_table_info['id']:
+            for table_id in redacted_table_info["id"]:
                 update_version(syn, table_id, comment)
         logger.info("Updating version for %s tables" % table_type)
-        for table_id in master_table['id']:
+        for table_id in master_table["id"]:
             update_version(syn, table_id, comment)
         logger.info("Table update is completed!")
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/table_updates/update_data_table.py
+++ b/scripts/table_updates/update_data_table.py
@@ -340,7 +340,6 @@ def custom_fix_for_cancer_panel_test_table(
     cpt_dat = cpt_dat_query.asDataFrame()
     cpt_dat.index = cpt_dat.index.map(str)
     cpt_dat["index"] = cpt_dat.index
-    # genie_sample_dat = syn.tableQuery('SELECT SAMPLE_ID, SEQ_YEAR FROM syn7517674').asDataFrame()
     genie_sample_dat = get_main_genie_clinical_sample_file(
         syn,
         release=config["main_genie_release_version"],

--- a/scripts/table_updates/update_data_table.py
+++ b/scripts/table_updates/update_data_table.py
@@ -51,11 +51,7 @@ def get_main_genie_clinical_sample_file(
         (release_files["release"] == release)
         & (release_files["name"] == "data_clinical_sample.txt")
     ]["fileSynId"].values[0]
-    clinical_link_ent = syn.get(clinical_link_synid)
-    clinical_ent = syn.get(
-        clinical_link_ent["linksTo"]["targetId"],
-        version=clinical_link_ent["linksTo"]["targetVersionNumber"],
-    )
+    clinical_ent = syn.get(clinical_link_synid, followLink=True)
     clinical_df = pandas.read_csv(clinical_ent.path, sep="\t", skiprows=4)
     assert (
         not clinical_df.empty

--- a/tests/test_update_data_table.py
+++ b/tests/test_update_data_table.py
@@ -1,0 +1,164 @@
+import json
+import os
+import pytest
+import re
+from unittest import mock
+
+import pandas as pd
+import synapseclient
+
+from scripts.table_updates import (
+    update_data_table,
+)
+
+
+@pytest.fixture
+def mock_syn():
+    return mock.create_autospec(synapseclient.Synapse)
+
+
+@pytest.fixture
+def mock_synapse(mock_syn):
+    # returns the mocked syn and release table synid
+    mock_syn = mock.MagicMock()
+    release_files_table_synid = "syn12345"
+    # Mock the tableQuery result
+    mock_syn.tableQuery.return_value.asDataFrame.return_value = pd.DataFrame(
+        {
+            "release": ["v1.0", "v2.0"],
+            "fileSynId": ["syn23456", "syn34567"],
+            "name": ["data_clinical_sample.txt", "data_clinical_patient.txt"],
+        }
+    )
+    # Mock the Link entity retrieval
+    clinical_link_ent_mock = {
+        "linksTo": {"targetId": "syn88888", "targetVersionNumber": 3}
+    }
+    mock_syn.get.return_value = mock.MagicMock(path="path/to/clinical_file.csv")
+    return mock_syn, release_files_table_synid
+
+
+@pytest.fixture
+def mock_release_version():
+    return "v1.0"
+
+
+@pytest.fixture
+def config():
+    yield {
+        "primary":{
+            "NSCLC": "syn23285494",
+            "CRC": "syn23285418",
+            "BrCa": "syn23286608",
+            "PANC": "syn24175803",
+            "Prostate": "syn25610393",
+            "BLADDER": "syn26721150",
+            "NSCLC2": "syn51318735",
+            "CRC2": "syn52943208",
+            "RENAL": "syn59474241"
+        },
+        "irr":{
+            "BrCa": "syn24241519",
+            "PANC": "syn25610271",
+            "Prostate": "syn26275497",
+            "BLADDER": "syn26721151",
+            "NSCLC2": "syn51318736",
+            "CRC2": "syn52943210",
+            "RENAL": "syn59474249"
+        },
+        "main_genie_release_version": "16.6-consortium",
+        "main_genie_data_release_files": "syn16804261",
+        "main_genie_sample_mapping_table": "syn7434273"
+    }
+
+
+
+def test_get_main_genie_clinical_sample_file_success(
+    mock_synapse, mock_release_version
+):
+    mock_syn, mock_release_files_table_synid = mock_synapse
+    # Mock pandas.read_csv to return a non-empty DataFrame
+    clinical_df_mock = pd.DataFrame(
+        {"SAMPLE_ID": [1, 2, 3], "SEQ_YEAR": [2014, 2014, 2013], "OTHER_ID": [6, 7, 8]}
+    )
+    pd.read_csv = mock.MagicMock(return_value=clinical_df_mock)
+
+    # Call the function
+    update_data_table.get_main_genie_clinical_sample_file(
+        mock_syn, mock_release_version, mock_release_files_table_synid
+    )
+    mock_syn.tableQuery.assert_called_once_with(
+        f"SELECT * FROM {mock_release_files_table_synid}"
+    )
+    # Assert that syn.get was called in order
+    mock_syn.get.assert_called_with("syn23456", followLink=True)
+    pd.read_csv.assert_called_once_with(
+        "path/to/clinical_file.csv", sep="\t", skiprows=4
+    )
+
+
+def test_get_main_genie_clinical_sample_file_empty_file(
+    mock_synapse, mock_release_version
+):
+    mock_syn, mock_release_files_table_synid = mock_synapse
+
+    # Mock pandas.read_csv to return an empty DataFrame
+    pd.read_csv = mock.MagicMock(return_value=pd.DataFrame())
+
+    # Call the function and assert the assertion error is raised
+    with pytest.raises(
+        AssertionError, match="Clinical file pulled from syn23456 link is empty."
+    ):
+        update_data_table.get_main_genie_clinical_sample_file(
+            mock_syn, mock_release_version, mock_release_files_table_synid
+        )
+
+    mock_syn.tableQuery.assert_called_once_with(
+        f"SELECT * FROM {mock_release_files_table_synid}"
+    )
+    # Assert that syn.get was called in order
+    mock_syn.get.assert_called_with("syn23456", followLink=True)
+    pd.read_csv.assert_called_once_with(
+        "path/to/clinical_file.csv", sep="\t", skiprows=4
+    )
+
+
+def test_get_main_genie_clinical_sample_file_no_req_cols(
+    mock_synapse, mock_release_version
+):
+    mock_syn, mock_release_files_table_synid = mock_synapse
+
+    # Mock pandas.read_csv to return an empty DataFrame
+    pd.read_csv = mock.MagicMock(return_value=pd.DataFrame({"col1": [1, 2, 3]}))
+
+    # Call the function and assert the assertion error is raised
+    with pytest.raises(
+        AssertionError,
+        match=re.escape(
+            "Clinical file pulled from syn23456 link is missing an expected column. "
+            "Expected columns: ['SAMPLE_ID', 'SEQ_YEAR']"
+        ),
+    ):
+        update_data_table.get_main_genie_clinical_sample_file(
+            mock_syn, mock_release_version, mock_release_files_table_synid
+        )
+
+    mock_syn.tableQuery.assert_called_once_with(
+        f"SELECT * FROM {mock_release_files_table_synid}"
+    )
+    # Assert that syn.get was called in order
+    mock_syn.get.assert_called_with("syn23456", followLink=True)
+    pd.read_csv.assert_called_once_with(
+        "path/to/clinical_file.csv", sep="\t", skiprows=4
+    )
+
+
+@pytest.mark.skip(reason="This test is skipped because this integration test doesn't work in pytest env")
+def test_get_main_genie_clinical_sample_file_integration_test(config):
+    syn = synapseclient.login()
+
+    update_data_table.get_main_genie_clinical_sample_file(
+        syn,
+        release=config["main_genie_release_version"],
+        release_files_table_synid=config["main_genie_data_release_files"],
+    )


### PR DESCRIPTION
**Purpose:** Due to an issue with the main genie prod clinical sample database data, and because `custom_fix` pulls from that table, we've refactored `custom_fix` to pull from the clinical sample file from a main genie consortium release.

**Changes:**
- `get_main_genie_clinical_sample_file` - this is a new function to get the clinical sample data for us. [See changes](https://github.com/Sage-Bionetworks/genie-bpc-pipeline/blob/gen-1458-fix-custom-fix/scripts/table_updates/update_data_table.py#L33)
- `custom_fix` (renamed to `custom_fix_for_cancer_panel_test_table`) - refactored to use `get_main_genie_clinical_sample_file` function instead of reading from the clinical sample db. [See changes](https://github.com/Sage-Bionetworks/genie-bpc-pipeline/blob/gen-1458-fix-custom-fix/scripts/table_updates/update_data_table.py#L344-L348)

**Testing:**
- Unit tests
- Running test run