### PR TITLE
[GEN-1479] Add in nextflow workflow for case selection

### DIFF
--- a/modules/run_export_bpc_selected_cases.nf
+++ b/modules/run_export_bpc_selected_cases.nf
@@ -19,6 +19,6 @@ process run_export_bpc_selected_cases {
     script:
     """
     cd /usr/local/src/myscripts/
-    Rscript export_bpc_selected_cases.R -i $bpc_input -o $output_synid --phase $phase --cohort $cohort --site $center
+    Rscript export_bpc_selected_cases.R -i $bpc_input -o $output_synid --phase "$phase" --cohort $cohort --site $center
     """
 }

--- a/modules/run_export_bpc_selected_cases.nf
+++ b/modules/run_export_bpc_selected_cases.nf
@@ -2,7 +2,7 @@
 Run workflow case selection
 */
 process run_export_bpc_selected_cases {
-    container 'sagebionetworks/genie-bpc-pipeline-case-selection'
+    container 'sagebionetworks/genie-bpc-pipeline-case-selection:develop'
     secret 'SYNAPSE_AUTH_TOKEN'
     debug true
 

--- a/modules/run_export_bpc_selected_cases.nf
+++ b/modules/run_export_bpc_selected_cases.nf
@@ -7,28 +7,18 @@ process run_export_bpc_selected_cases {
     debug true
 
     input:
+    val bpc_input
+    val output_synid
     val phase
     val cohort
     val center
-    val production
 
     output:
     stdout
-    // path "nsclc_dfci_phase1_case_selection.csv"
-    // path "nsclc_dfci_phase1_eligibility_matrix.csv"
-    // path "${params.cohort}_dfci_phase1_eligibility_matrix.csv"
 
     script:
-    if (production) {
-        """
-        cd /usr/local/src/myscripts/
-        python3 workflow_case_selection.py --phase $phase --cohort $cohort --site $center -u
-        """
-    }
-    else {
-        """
-        cd /usr/local/src/myscripts/
-        python3 workflow_case_selection.py -p $phase -c $cohort -s $center
-        """
-    }
+    """
+    cd /usr/local/src/myscripts/
+    Rscript export_bpc_selected_cases.R -i $bpc_input -o $output_synid --phase $phase --cohort $cohort --site $center
+    """
 }

--- a/modules/run_export_bpc_selected_cases.nf
+++ b/modules/run_export_bpc_selected_cases.nf
@@ -2,7 +2,7 @@
 Run workflow case selection
 */
 process run_export_bpc_selected_cases {
-    container 'sagebionetworks/genie-bpc-pipeline-case-selection:develop'
+    container 'sagebionetworks/genie-bpc-pipeline-case-selection'
     secret 'SYNAPSE_AUTH_TOKEN'
     debug true
 

--- a/modules/run_export_bpc_selected_cases.nf
+++ b/modules/run_export_bpc_selected_cases.nf
@@ -1,0 +1,34 @@
+/*
+Run workflow case selection
+*/
+process run_export_bpc_selected_cases {
+    container 'sagebionetworks/genie-bpc-pipeline-case-selection'
+    secret 'SYNAPSE_AUTH_TOKEN'
+    debug true
+
+    input:
+    val phase
+    val cohort
+    val center
+    val production
+
+    output:
+    stdout
+    // path "nsclc_dfci_phase1_case_selection.csv"
+    // path "nsclc_dfci_phase1_eligibility_matrix.csv"
+    // path "${params.cohort}_dfci_phase1_eligibility_matrix.csv"
+
+    script:
+    if (production) {
+        """
+        cd /usr/local/src/myscripts/
+        python3 workflow_case_selection.py --phase $phase --cohort $cohort --site $center -u
+        """
+    }
+    else {
+        """
+        cd /usr/local/src/myscripts/
+        python3 workflow_case_selection.py -p $phase -c $cohort -s $center
+        """
+    }
+}

--- a/modules/run_workflow_case_selection.nf
+++ b/modules/run_workflow_case_selection.nf
@@ -2,7 +2,7 @@
 Run workflow case selection
 */
 process run_workflow_case_selection {
-    container 'sagebionetworks/genie-bpc-pipeline-case-selection'
+    container 'sagebionetworks/genie-bpc-pipeline-case-selection:develop'
     secret 'SYNAPSE_AUTH_TOKEN'
     debug true
 

--- a/modules/run_workflow_case_selection.nf
+++ b/modules/run_workflow_case_selection.nf
@@ -1,0 +1,34 @@
+/*
+Run workflow case selection
+*/
+process run_workflow_case_selection {
+    container 'sagebionetworks/genie-bpc-pipeline-case-selection'
+    secret 'SYNAPSE_AUTH_TOKEN'
+    debug true
+
+    input:
+    val phase
+    val cohort
+    val center
+    val production
+
+    output:
+    stdout
+    // path "nsclc_dfci_phase1_case_selection.csv"
+    // path "nsclc_dfci_phase1_eligibility_matrix.csv"
+    // path "${params.cohort}_dfci_phase1_eligibility_matrix.csv"
+
+    script:
+    if (production) {
+        """
+        cd /case_selection
+        python3 workflow_case_selection.py --phase $phase --cohort $cohort --site $center -u
+        """
+    }
+    else {
+        """
+        cd /case_selection
+        python3 workflow_case_selection.py -p $phase -c $cohort -s $center
+        """
+    }
+}

--- a/modules/run_workflow_case_selection.nf
+++ b/modules/run_workflow_case_selection.nf
@@ -21,14 +21,14 @@ process run_workflow_case_selection {
     script:
     if (production) {
         """
-        cd /case_selection
-        python3 workflow_case_selection.py --phase $phase --cohort $cohort --site $center -u
+        cd /usr/local/src/myscripts/
+        Rscript workflow_case_selection.R --phase $phase --cohort $cohort --site $center -u
         """
     }
     else {
         """
-        cd /case_selection
-        python3 workflow_case_selection.py -p $phase -c $cohort -s $center
+        cd /usr/local/src/myscripts/
+        Rscript workflow_case_selection.R -p $phase -c $cohort -s $center
         """
     }
 }

--- a/modules/run_workflow_case_selection.nf
+++ b/modules/run_workflow_case_selection.nf
@@ -2,7 +2,7 @@
 Run workflow case selection
 */
 process run_workflow_case_selection {
-    container 'sagebionetworks/genie-bpc-pipeline-case-selection:develop'
+    container 'sagebionetworks/genie-bpc-pipeline-case-selection'
     secret 'SYNAPSE_AUTH_TOKEN'
     debug true
 

--- a/nextflow.config
+++ b/nextflow.config
@@ -17,6 +17,10 @@ profiles {
 				memory = 32.GB
 				cpus = 8
 			}
+			withName: run_export_bpc_selected_cases {
+				memory = 32.GB
+				cpus = 8
+			}
 			withName: run_quac_upload_report_warning {
 				memory = 32.GB
 				cpus = 8

--- a/nextflow.config
+++ b/nextflow.config
@@ -13,7 +13,7 @@ manifest {
 profiles {
 	aws_prod {
 		process {
-			withName: case_selection {
+			withName: run_workflow_case_selection {
 				memory = 32.GB
 				cpus = 8
 			}

--- a/nextflow.config
+++ b/nextflow.config
@@ -13,6 +13,10 @@ manifest {
 profiles {
 	aws_prod {
 		process {
+			withName: case_selection {
+				memory = 32.GB
+				cpus = 8
+			}
 			withName: run_quac_upload_report_warning {
 				memory = 32.GB
 				cpus = 8

--- a/scripts/case_selection/Dockerfile
+++ b/scripts/case_selection/Dockerfile
@@ -1,27 +1,23 @@
-FROM r-base:4.0.5
+FROM rstudio/r-base:4.0-bullseye
 
 WORKDIR /usr/local/src/myscripts
 
 ENV RENV_VERSION 0.14.0
 
-RUN rm /etc/apt/apt.conf.d/default
-RUN apt-get update -y
-RUN apt-get install -y dpkg-dev zlib1g-dev libssl-dev libffi-dev
-# procps is required for nextflow tower
-RUN apt-get install -y curl libcurl4-openssl-dev procps
-RUN R -e "install.packages('synapser', repos=c('http://ran.synapse.org', 'http://cran.fhcrc.org'))"
-
-ENV PYTHON /usr/local/lib/R/site-library/PythonEmbedInR/bin/python3.6
+# RUN rm /etc/apt/apt.conf.d/default
+RUN apt-get update -y && apt-get install -y dpkg-dev zlib1g-dev libssl-dev libffi-dev curl libcurl4-openssl-dev procps
 
 RUN R -e "install.packages('remotes', repos = c(CRAN = 'https://cloud.r-project.org'))"
 RUN R -e "remotes::install_github('rstudio/renv@${RENV_VERSION}')"
+RUN R -e "remotes::install_version('synapser', version = '0.11.7', repos = c('http://ran.synapse.org', 'http://cran.fhcrc.org'))"
 
-COPY . .
-
-RUN R -e "renv::restore()"
-
+ENV PYTHON /usr/local/lib/R/site-library/PythonEmbedInR/bin/python3.6
 #install pandoc 1.19.2.1 (dashboard use)
 # RUN wget https://github.com/jgm/pandoc/releases/download/1.19.2.1/pandoc-1.19.2.1-1-amd64.deb
 # RUN dpkg -i pandoc-1.19.2.1-1-amd64.deb
 RUN wget https://github.com/jgm/pandoc/releases/download/3.0.1/pandoc-3.0.1-1-amd64.deb
 RUN dpkg -i pandoc-3.0.1-1-amd64.deb
+
+COPY . .
+
+RUN R -e "renv::restore()"

--- a/scripts/case_selection/Dockerfile
+++ b/scripts/case_selection/Dockerfile
@@ -19,3 +19,9 @@ RUN R -e "remotes::install_github('rstudio/renv@${RENV_VERSION}')"
 COPY . .
 
 RUN R -e "renv::restore()"
+
+#install pandoc 1.19.2.1 (dashboard use)
+# RUN wget https://github.com/jgm/pandoc/releases/download/1.19.2.1/pandoc-1.19.2.1-1-amd64.deb
+# RUN dpkg -i pandoc-1.19.2.1-1-amd64.deb
+RUN wget https://github.com/jgm/pandoc/releases/download/3.0.1/pandoc-3.0.1-1-amd64.deb
+RUN dpkg -i pandoc-3.0.1-1-amd64.deb

--- a/scripts/case_selection/Dockerfile
+++ b/scripts/case_selection/Dockerfile
@@ -1,4 +1,4 @@
-FROM r-base:4.0.0
+FROM r-base:4.0.5
 
 WORKDIR /usr/local/src/myscripts
 

--- a/scripts/case_selection/export_bpc_selected_cases.R
+++ b/scripts/case_selection/export_bpc_selected_cases.R
@@ -36,7 +36,7 @@ option_list <- list(
 )
 opt <- parse_args(OptionParser(option_list=option_list))
 
-if (!is.null(opt$input) && !is.null(opt$phase) && !is.null(opt$cohort) && !is.null(opt$site)) {
+if (!is.null(opt$input) || !is.null(opt$phase) || !is.null(opt$cohort) || !is.null(opt$site)) {
   stop("Usage: Rscript export_bpc_selected_cases.R -h")
 }
 

--- a/scripts/case_selection/export_bpc_selected_cases.R
+++ b/scripts/case_selection/export_bpc_selected_cases.R
@@ -121,7 +121,7 @@ print("get all samples for selected patients")
 # Get all samples for those patients
 # samples_per_patient <- sapply(selected_cases, function(x){as.character(clinical$sample_id[clinical$patient_id %in% x])})
 missing_patients <- selected_cases[!selected_cases %in% !clinical$patient_id]
-print("Missing patients froim consortium release:")
+print("Missing patients from consortium release:")
 print(missing_patients)
 
 samples_per_patient <- clinical$sample_id[clinical$patient_id %in% selected_cases]

--- a/scripts/case_selection/export_bpc_selected_cases.R
+++ b/scripts/case_selection/export_bpc_selected_cases.R
@@ -36,7 +36,7 @@ option_list <- list(
 )
 opt <- parse_args(OptionParser(option_list=option_list))
 
-if (!is.null(opt$input) || !is.null(opt$phase) || !is.null(opt$cohort) || !is.null(opt$site)) {
+if (is.null(opt$input) || is.null(opt$phase) || is.null(opt$cohort) || is.null(opt$site)) {
   stop("Usage: Rscript export_bpc_selected_cases.R -h")
 }
 

--- a/scripts/case_selection/export_bpc_selected_cases.R
+++ b/scripts/case_selection/export_bpc_selected_cases.R
@@ -120,7 +120,7 @@ colnames(clinical) <- tolower(colnames(clinical))
 print("get all samples for selected patients")
 # Get all samples for those patients
 # samples_per_patient <- sapply(selected_cases, function(x){as.character(clinical$sample_id[clinical$patient_id %in% x])})
-missing_patients <- selected_cases[!selected_cases %in% !clinical$patient_id]
+missing_patients <- selected_cases[!selected_cases %in% clinical$patient_id]
 print("Missing patients from consortium release:")
 print(missing_patients)
 

--- a/scripts/case_selection/export_bpc_selected_cases.R
+++ b/scripts/case_selection/export_bpc_selected_cases.R
@@ -51,21 +51,21 @@ site <- opt$site
 # file_view_schema <- synGetColumns(file_view_id)$asList()
 
 phase_option <- c("phase 1","phase 1 additional","phase 2")
-cohort_option <- c("NSCLC","CRC","BrCa","PANC","Prostate","BLADDER")
-site_option <- c("DFCI","MSK","UHN","VICC")
+cohort_option <- c("NSCLC","CRC","BrCa","PANC","Prostate","BLADDER", "MELANOMA", "RENAL", "OVARIAN", "ESOPHAGO")
+site_option <- c("DFCI","MSK","UHN","VICC","UCSF")
 
 phase_str <- paste0(phase_option, collapse = ", ")
-waitifnot(is.element(phase, phase_option),
+stopifnot(is.element(phase, phase_option),
           msg=c(glue("Error: {phase} is not a valid phase. Valid values: {phase_str}"),
                   "Usage: export_bpc_selected_cases.R -h"))
 
 cohort_str <- paste0(cohort_option, collapse = ", ")
-waitifnot(is.element(cohort, cohort_option),
+stopifnot(is.element(cohort, cohort_option),
           msg=c(glue("Error: {cohort} is not a valid cohort. Valid values: {cohort_str}"),
                   "Usage: export_bpc_selected_cases.R -h"))
 
 site_str <- paste0(site_option, collapse = ", ")
-waitifnot(is.element(site, site_option),
+stopifnot(is.element(site, site_option),
           msg=c(glue("Error: {site} is not a valid site. Valid values: {site_str}"),
                   "Usage: export_bpc_selected_cases.R -h"))
 

--- a/scripts/case_selection/export_bpc_selected_cases.R
+++ b/scripts/case_selection/export_bpc_selected_cases.R
@@ -70,7 +70,7 @@ stopifnot(is.element(site, site_option),
                   "Usage: export_bpc_selected_cases.R -h"))
 
 # setup ----------------------------
-
+print("get clinical data")
 # clinical data
 # always use the most recent consortium release - Feb 2022
 clinical_sample_id <- "syn9734573"
@@ -112,10 +112,16 @@ clinical <- sqldf(sql)
 
 # change the columns to lower case
 colnames(clinical) <- tolower(colnames(clinical))
-
+print("get all samples for selected patients")
 # Get all samples for those patients
-samples_per_patient <- sapply(selected_cases, function(x){as.character(clinical$sample_id[clinical$patient_id %in% x])})
+# samples_per_patient <- sapply(selected_cases, function(x){as.character(clinical$sample_id[clinical$patient_id %in% x])})
+missing_patients <- selected_cases[!selected_cases %in% !clinical$patient_id]
+print("Missing patients froim consortium release:")
+print(missing_patients)
 
+samples_per_patient <- clinical$sample_id[clinical$patient_id %in% selected_cases]
+
+print("map data for each instrument")
 # mapping data for each instrument
 # instrument - patient_characteristics
 patient_output <- data.frame("record_id" = selected_cases)
@@ -136,7 +142,7 @@ patient_output$naaccr_race_code_primary <- race_mapping$CODE[match(patient_outpu
 patient_output$naaccr_race_code_secondary <- race_mapping$CODE[match(patient_output$naaccr_race_code_secondary, race_mapping$CBIO_LABEL)]
 patient_output$naaccr_race_code_tertiary <- race_mapping$CODE[match(patient_output$naaccr_race_code_tertiary, race_mapping$CBIO_LABEL)]
 patient_output$naaccr_sex_code <- sex_mapping$CODE[match(patient_output$naaccr_sex_code,sex_mapping$CBIO_LABEL)]
-
+print("recode")
 # recode
 # cannotReleaseHIPAA = NA
 patient_output$birth_year[which(patient_output$birth_year == "cannotReleaseHIPAA")] <- NA
@@ -148,7 +154,7 @@ patient_output$naaccr_race_code_primary[which(patient_output$naaccr_race_code_pr
 patient_output$naaccr_race_code_secondary[which(patient_output$naaccr_race_code_secondary == -1)] <- 88
 patient_output$naaccr_race_code_tertiary[which(patient_output$naaccr_race_code_tertiary == -1)] <- 88
 
-
+print("instrument cancer panel test")
 # instrument - cancer_panel_test
 sample_info_list <- lapply(samples_per_patient,function(x){
   sample_list = list()
@@ -172,7 +178,7 @@ sample_info_list <- lapply(samples_per_patient,function(x){
 
 sample_info_df <- rbind.fill(sample_info_list)
 patient_output <- rbind.fill(patient_output,sample_info_df)
-
+print("output and upload")
 # output and upload ----------------------------
 write.csv(patient_output,file = output_file_name,quote = TRUE,row.names = FALSE,na = "")
 act <- Activity(name = 'export main GENIE data', 

--- a/scripts/case_selection/export_bpc_selected_cases.R
+++ b/scripts/case_selection/export_bpc_selected_cases.R
@@ -52,7 +52,7 @@ site <- opt$site
 
 phase_option <- c("phase 1","phase 1 additional","phase 2")
 cohort_option <- c("NSCLC","CRC","BrCa","PANC","Prostate","BLADDER", "MELANOMA", "RENAL", "OVARIAN", "ESOPHAGO")
-site_option <- c("DFCI","MSK","UHN","VICC","UCSF")
+site_option <- c("DFCI","MSK","UHN","VICC","UCSF","PROV","VHIO","JHU","WAKE")
 
 phase_str <- paste0(phase_option, collapse = ", ")
 stopifnot(is.element(phase, phase_option),

--- a/scripts/case_selection/export_bpc_selected_cases.R
+++ b/scripts/case_selection/export_bpc_selected_cases.R
@@ -77,7 +77,7 @@ if (!is.element(site, site_option)) {
 # setup ----------------------------
 print("get clinical data")
 # clinical data
-# always use the most recent consortium release - Feb 2022
+# HACK: always use the most recent consortium release at the time of execution of this code
 clinical_sample_id <- "syn9734573"
 clinical_patient_id <- "syn9734568"
 

--- a/scripts/case_selection/export_bpc_selected_cases.R
+++ b/scripts/case_selection/export_bpc_selected_cases.R
@@ -193,7 +193,7 @@ act <- Activity(name = 'export main GENIE data',
 syn_file <- File(output_file_name, 
                  parent=out_folder,
                  name=output_entity_name,
-                 annotations=list(phase=phase,cohort=cohort,site=site))
+                 annotations=list(phase=sub("phase ", "", phase),cohort=cohort,site=site))
 syn_file <- synStore(syn_file)
 synSetProvenance(syn_file,act)
 file.remove(output_file_name)

--- a/scripts/case_selection/export_bpc_selected_cases.R
+++ b/scripts/case_selection/export_bpc_selected_cases.R
@@ -35,8 +35,10 @@ option_list <- list(
               help="BPC site. i.e. DFCI, MSK, UHN, VICC, and etc.")
 )
 opt <- parse_args(OptionParser(option_list=option_list))
-waitifnot(!is.null(opt$input) &&!is.null(opt$phase) && !is.null(opt$cohort) && 
-            !is.null(opt$site), msg = "Usage: Rscript export_bpc_selected_cases.R -h")
+
+if (!is.null(opt$input) && !is.null(opt$phase) && !is.null(opt$cohort) && !is.null(opt$site)) {
+  stop("Usage: Rscript export_bpc_selected_cases.R -h")
+}
 
 in_file <- opt$input
 out_folder <- opt$output
@@ -54,20 +56,23 @@ phase_option <- c("phase 1","phase 1 additional","phase 2")
 cohort_option <- c("NSCLC","CRC","BrCa","PANC","Prostate","BLADDER", "MELANOMA", "RENAL", "OVARIAN", "ESOPHAGO")
 site_option <- c("DFCI","MSK","UHN","VICC","UCSF","PROV","VHIO","JHU","WAKE")
 
+# Check if phase is valid
 phase_str <- paste0(phase_option, collapse = ", ")
-stopifnot(is.element(phase, phase_option),
-          msg=c(glue("Error: {phase} is not a valid phase. Valid values: {phase_str}"),
-                  "Usage: export_bpc_selected_cases.R -h"))
+if (!is.element(phase, phase_option)) {
+  stop(glue("Error: {phase} is not a valid phase. Valid values: {phase_str}\nUsage: export_bpc_selected_cases.R -h"))
+}
 
+# Check if cohort is valid
 cohort_str <- paste0(cohort_option, collapse = ", ")
-stopifnot(is.element(cohort, cohort_option),
-          msg=c(glue("Error: {cohort} is not a valid cohort. Valid values: {cohort_str}"),
-                  "Usage: export_bpc_selected_cases.R -h"))
+if (!is.element(cohort, cohort_option)) {
+  stop(glue("Error: {cohort} is not a valid cohort. Valid values: {cohort_str}\nUsage: export_bpc_selected_cases.R -h"))
+}
 
+# Check if site is valid
 site_str <- paste0(site_option, collapse = ", ")
-stopifnot(is.element(site, site_option),
-          msg=c(glue("Error: {site} is not a valid site. Valid values: {site_str}"),
-                  "Usage: export_bpc_selected_cases.R -h"))
+if (!is.element(site, site_option)) {
+  stop(glue("Error: {site} is not a valid site. Valid values: {site_str}\nUsage: export_bpc_selected_cases.R -h"))
+}
 
 # setup ----------------------------
 

--- a/scripts/case_selection/workflow_case_selection.R
+++ b/scripts/case_selection/workflow_case_selection.R
@@ -27,7 +27,7 @@ option_list <- list(
 )
 opt <- parse_args(OptionParser(option_list=option_list))
 
-if (!is.null(opt$phase) && !is.null(opt$cohort) && !is.null(opt$site)) {
+if (!is.null(opt$phase) || !is.null(opt$cohort) || !is.null(opt$site)) {
   stop("Usage: Rscript workflow_case_selection.R -h")
 }
 phase <- opt$phase

--- a/scripts/case_selection/workflow_case_selection.R
+++ b/scripts/case_selection/workflow_case_selection.R
@@ -27,7 +27,7 @@ option_list <- list(
 )
 opt <- parse_args(OptionParser(option_list=option_list))
 
-if (!is.null(opt$phase) || !is.null(opt$cohort) || !is.null(opt$site)) {
+if (is.null(opt$phase) || is.null(opt$cohort) || is.null(opt$site)) {
   stop("Usage: Rscript workflow_case_selection.R -h")
 }
 phase <- opt$phase

--- a/scripts/case_selection/workflow_case_selection.R
+++ b/scripts/case_selection/workflow_case_selection.R
@@ -26,9 +26,10 @@ option_list <- list(
               help="Save output to production folder")
 )
 opt <- parse_args(OptionParser(option_list=option_list))
-waitifnot(!is.null(opt$phase) && !is.null(opt$cohort) && !is.null(opt$site),
-          msg = "Usage: Rscript workflow_case_selection.R -h")
 
+if (!is.null(opt$phase) && !is.null(opt$cohort) && !is.null(opt$site)) {
+  stop("Usage: Rscript workflow_case_selection.R -h")
+}
 phase <- opt$phase
 cohort <- opt$cohort
 site <- opt$site
@@ -36,22 +37,21 @@ is_production <- opt$production
 
 # check user input -----------------
 
-phase_str <- paste0(names(config$phase), collapse = ", ")
-waitifnot(is.element(phase, names(config$phase)),
-          msg = c(glue("Error: phase {phase} is not valid.  Valid values: {phase_str}"),
-                  "Usage: Rscript workflow_case_selection.R -h"))
+if (!is.element(phase, names(config$phase))) {
+  stop(glue("Error: {phase} is not a valid phase. Valid values: {phase_str}\nUsage: workflow_case_selection.R -h"))
+}
 
 cohort_in_config <- names(config$phase[[phase]]$cohort)
 cohort_str <- paste0(cohort_in_config, collapse = ", ")
-waitifnot(is.element(cohort, cohort_in_config),
-          msg = c(glue("Error: cohort {cohort} is not valid for phase {phase}.  Valid values: {cohort_str}"),
-                  "Usage: Rscript workflow_case_selection.R -h"))
+if (!is.element(cohort, cohort_in_config)) {
+  stop(glue("Error: {cohort} is not a valid cohort. Valid values: {cohort_str}\nUsage: workflow_case_selection.R -h"))
+}
 
 sites_in_config <- get_sites_in_config(config, phase, cohort)
 site_str <- paste0(sites_in_config, collapse = ", ")
-stopifnot(is.element(site, sites_in_config),
-          msg = c(glue("Error: site {site} is not valid for phase {phase} and cohort {cohort}.  Valid values: {site_str}"),
-                  "Usage: Rscript workflow_case_selection.R -h"))
+if (!is.element(site, sites_in_config)) {
+  stop(glue("Error: {site} is not a valid site. Valid values: {site_str}\nUsage: workflow_case_selection.R -h"))
+}
 
 # setup ----------------------------
 

--- a/scripts/case_selection/workflow_case_selection.R
+++ b/scripts/case_selection/workflow_case_selection.R
@@ -26,7 +26,7 @@ option_list <- list(
               help="Save output to production folder")
 )
 opt <- parse_args(OptionParser(option_list=option_list))
-waitifnot(!is.null(opt$phase) && !is.null(opt$cohort) && !is.null(opt$site),
+stopifnot(!is.null(opt$phase) && !is.null(opt$cohort) && !is.null(opt$site),
           msg = "Usage: Rscript workflow_case_selection.R -h")
 
 phase <- opt$phase
@@ -37,19 +37,19 @@ is_production <- opt$production
 # check user input -----------------
 
 phase_str <- paste0(names(config$phase), collapse = ", ")
-waitifnot(is.element(phase, names(config$phase)),
+stopifnot(is.element(phase, names(config$phase)),
           msg = c(glue("Error: phase {phase} is not valid.  Valid values: {phase_str}"),
                   "Usage: Rscript workflow_case_selection.R -h"))
 
 cohort_in_config <- names(config$phase[[phase]]$cohort)
 cohort_str <- paste0(cohort_in_config, collapse = ", ")
-waitifnot(is.element(cohort, cohort_in_config),
+stopifnot(is.element(cohort, cohort_in_config),
           msg = c(glue("Error: cohort {cohort} is not valid for phase {phase}.  Valid values: {cohort_str}"),
                   "Usage: Rscript workflow_case_selection.R -h"))
 
 sites_in_config <- get_sites_in_config(config, phase, cohort)
 site_str <- paste0(sites_in_config, collapse = ", ")
-waitifnot(is.element(site, sites_in_config),
+stopifnot(is.element(site, sites_in_config),
           msg = c(glue("Error: site {site} is not valid for phase {phase} and cohort {cohort}.  Valid values: {site_str}"),
                   "Usage: Rscript workflow_case_selection.R -h"))
 

--- a/scripts/case_selection/workflow_case_selection.R
+++ b/scripts/case_selection/workflow_case_selection.R
@@ -26,7 +26,7 @@ option_list <- list(
               help="Save output to production folder")
 )
 opt <- parse_args(OptionParser(option_list=option_list))
-stopifnot(!is.null(opt$phase) && !is.null(opt$cohort) && !is.null(opt$site),
+waitifnot(!is.null(opt$phase) && !is.null(opt$cohort) && !is.null(opt$site),
           msg = "Usage: Rscript workflow_case_selection.R -h")
 
 phase <- opt$phase
@@ -37,13 +37,13 @@ is_production <- opt$production
 # check user input -----------------
 
 phase_str <- paste0(names(config$phase), collapse = ", ")
-stopifnot(is.element(phase, names(config$phase)),
+waitifnot(is.element(phase, names(config$phase)),
           msg = c(glue("Error: phase {phase} is not valid.  Valid values: {phase_str}"),
                   "Usage: Rscript workflow_case_selection.R -h"))
 
 cohort_in_config <- names(config$phase[[phase]]$cohort)
 cohort_str <- paste0(cohort_in_config, collapse = ", ")
-stopifnot(is.element(cohort, cohort_in_config),
+waitifnot(is.element(cohort, cohort_in_config),
           msg = c(glue("Error: cohort {cohort} is not valid for phase {phase}.  Valid values: {cohort_str}"),
                   "Usage: Rscript workflow_case_selection.R -h"))
 

--- a/scripts/case_selection/workflow_case_selection.R
+++ b/scripts/case_selection/workflow_case_selection.R
@@ -177,10 +177,7 @@ if (file.exists(file_selection)) {
 
 
 # close out ----------------------------
-
-if (save_synapse) {
-  print(glue("Output saved to Synapse ({synid_folder_output})"))
-}
+print(glue("Output saved to Synapse ({synid_folder_output})"))
 
 toc = as.double(Sys.time())
 print(glue("Runtime: {round(toc - tic)} s"))

--- a/subworkflows/case_selection_workflow.nf
+++ b/subworkflows/case_selection_workflow.nf
@@ -1,0 +1,17 @@
+// Case selection workflow
+nextflow.enable.dsl = 2
+
+// phase
+params.phase = "1"
+// cohort
+params.cohort = "NSCLC"
+// center
+params.center = "DFCI"
+params.production = false
+
+// import modules
+include { run_workflow_case_selection } from '../modules/run_workflow_case_selection.nf'
+
+workflow case_selection_workflow {
+    run_workflow_case_selection(params.phase, params.cohort, params.center, params.production)
+}

--- a/subworkflows/case_selection_workflow.nf
+++ b/subworkflows/case_selection_workflow.nf
@@ -8,10 +8,26 @@ params.cohort = "NSCLC"
 // center
 params.center = "DFCI"
 params.production = false
+params.bpc_input = "syn53294194"
+params.bpc_output = "syn62147862"
+export_phase = "phase " + params.phase
 
 // import modules
-include { run_workflow_case_selection } from '../modules/run_workflow_case_selection.nf'
+include { run_workflow_case_selection } from '../modules/run_workflow_case_selection'
+include { run_export_bpc_selected_cases } from '../modules/run_export_bpc_selected_cases'
+
+workflow export_bpc_cases {
+    // run_workflow_case_selection(params.phase, params.cohort, params.center, params.production)
+    run_export_bpc_selected_cases(params.bpc_input, params.bpc_output, params.phase, params.cohort, params.center)
+}
+
+
+workflow case_selection {
+    run_workflow_case_selection(params.phase, params.cohort, params.center, params.production)
+    // run_export_bpc_selected_cases(params.bpc_input, params.bpc_output, params.phase, params.cohort, params.center)
+}
 
 workflow case_selection_workflow {
     run_workflow_case_selection(params.phase, params.cohort, params.center, params.production)
+    run_export_bpc_selected_cases(params.bpc_input, params.bpc_output, params.phase, params.cohort, params.center)
 }

--- a/subworkflows/case_selection_workflow.nf
+++ b/subworkflows/case_selection_workflow.nf
@@ -18,7 +18,7 @@ include { run_export_bpc_selected_cases } from '../modules/run_export_bpc_select
 
 workflow export_bpc_cases {
     // run_workflow_case_selection(params.phase, params.cohort, params.center, params.production)
-    run_export_bpc_selected_cases(params.bpc_input, params.bpc_output, params.phase, params.cohort, params.center)
+    run_export_bpc_selected_cases(params.bpc_input, params.bpc_output, export_phase, params.cohort, params.center)
 }
 
 

--- a/subworkflows/case_selection_workflow.nf
+++ b/subworkflows/case_selection_workflow.nf
@@ -27,7 +27,8 @@ workflow case_selection {
     // run_export_bpc_selected_cases(params.bpc_input, params.bpc_output, params.phase, params.cohort, params.center)
 }
 
-workflow case_selection_workflow {
-    run_workflow_case_selection(params.phase, params.cohort, params.center, params.production)
-    run_export_bpc_selected_cases(params.bpc_input, params.bpc_output, params.phase, params.cohort, params.center)
-}
+// TODO: This is commented out because the two steps currently don't connect together in a smooth way
+// workflow case_selection_workflow {
+//     run_workflow_case_selection(params.phase, params.cohort, params.center, params.production)
+//     run_export_bpc_selected_cases(params.bpc_input, params.bpc_output, params.phase, params.cohort, params.center)
+// }

--- a/subworkflows/nextflow.config
+++ b/subworkflows/nextflow.config
@@ -1,0 +1,42 @@
+env.cohorts = 'BLADDER BrCa CRC NSCLC PANC Prostate CRC2 NSCLC2 MELANOMA OVARIAN ESOPHAGO RENAL'
+docker.enabled = true
+
+manifest {
+	name = 'Sage-Bionetworks/genie-bpc-pipeline'
+	author = 'Thomas Yu'
+	homePage = 'https://github.com/Sage-Bionetworks/genie-bpc-pipeline'
+	description = 'Nextflow pipeline for first steps of GENIE BPC data processing'
+	mainScript = 'main.nf'
+	nextflowVersion = '>=21.04.0-edge'
+	version = '0.1'
+}
+profiles {
+	aws_prod {
+		process {
+			withName: case_selection {
+				memory = 32.GB
+				cpus = 8
+			}
+			withName: run_quac_upload_report_warning {
+				memory = 32.GB
+				cpus = 8
+			}
+			withName: run_quac_upload_report_error {
+				memory = 32.GB
+				cpus = 8
+			}
+			withName: update_data_table {
+				memory = 32.GB
+				cpus = 8
+			}
+			withName: merge_and_uncode_rca_uploads {
+				memory = 32.GB
+				cpus = 8
+			}
+			withName: remove_patients_from_merged {
+				memory = 32.GB
+				cpus = 8
+			}
+		}
+	}
+}


### PR DESCRIPTION
Add in nextflow workflow for the case selection steps, case selection and export file.

<img width="1439" alt="image" src="https://github.com/user-attachments/assets/628c0501-2c5a-4e55-a025-bc106012db06">

Locally: 
```
nextflow run case_selection_workflow.nf -entry case_selection --phase 2 --cohort MELANOMA --center UCSF
nextflow run case_selection_workflow.nf -entry export_bpc_cases --phase 2 --cohort MELANOMA --center UCSF --bpc_input syn62150662 --bpc_output syn62147862

```

Here are two successful executions for case selection and export bpc respectively by using phase 2, PROV and ovarian that was tested using the 17.2-consortium clinical database table AND consortium release.

* https://tower.sagebionetworks.org/orgs/Sage-Bionetworks/workspaces/genie-bpc-project/watch/5gecnMl4LrpX0n
* https://tower.sagebionetworks.org/orgs/Sage-Bionetworks/workspaces/genie-bpc-project/watch/1EAZDv2nMwOIZ2

