### PR TITLE
[GEN-1487] Get all eligible samples in export 

### DIFF
--- a/scripts/case_selection/export_bpc_selected_cases.R
+++ b/scripts/case_selection/export_bpc_selected_cases.R
@@ -95,18 +95,19 @@ output_file_name <- glue("{site}_{cohort}_{phase_no_space}_genie_export_{Sys.Dat
 # download input file and get selected cases/samples
 selected_info <- read.csv(synGet(in_file)$path)
 selected_cases <- selected_info$PATIENT_ID
-selected_samples <- unlist(strsplit(paste0(selected_info$SAMPLE_IDS,collapse=";"),";"))
+# selected_samples <- unlist(strsplit(paste0(selected_info$SAMPLE_IDS,collapse=";"),";"))
 
 # create the data file ----------------------------
 
 # Create query for selected cases
-temp <- toString(selected_samples)
+temp <- toString(unique(selected_cases))
 temp <- sapply(strsplit(temp, '[, ]+'), function(x) toString(shQuote(x)))
 
 # download clinical data
 # sample clinical data
+# Make sure to include all patients that have at least one sample that meet the eligibility criteria
 clinical_sample <- read.delim(synGet(clinical_sample_id, downloadFile = TRUE, followLink = TRUE)$path, skip = 4, header = TRUE)
-clinical_sample <- sqldf("SELECT * FROM clinical_sample")
+clinical_sample <- sqldf(paste("SELECT * FROM clinical_sample where PATIENT_ID in (",temp,")",sep = ""))
 
 # patient clinical data
 clinical_patient <- read.delim(synGet(clinical_patient_id, downloadFile = TRUE, followLink = TRUE)$path, skip = 4, header = TRUE)
@@ -183,6 +184,33 @@ sample_info_list <- lapply(samples_per_patient,function(x){
 
 sample_info_df <- rbind.fill(sample_info_list)
 patient_output <- rbind.fill(patient_output,sample_info_df)
+
+print("validate output")
+n_unique_patients_export = length(unique(sample_info_df$record_id))
+n_unique_samples_export = length(unique(sample_info_df$cpt_genie_sample_id))
+n_unique_selected_patients = length(unique(selected_cases))
+n_unique_selected_samples = length(unique(samples_per_patient))
+n_missing_patients = length(missing_patients)
+
+print(paste("export file N unique patients", n_unique_patients_export))
+print(paste("export file N unique samples", n_unique_samples_export))
+print(paste("N Unique selected patients", n_unique_selected_patients))
+print(paste("N Unique selected samples", n_unique_selected_samples))
+
+if (n_unique_samples_export != n_unique_selected_samples){
+  stop("Number of unique samples in export file does not match number of selected samples")
+}
+if (n_unique_patients_export != n_unique_selected_patients - n_missing_patients){
+  stop("Number of unique patients in export file does not match number of selected patients")
+}
+if (!all(patient_output$record_id %in% selected_cases)){
+  stop("Some patients in export file are not in selected patients")
+}
+# There is expected NA, because the export file is technically two csvs concatenated together
+if (!all(unique(na.omit(patient_output$cpt_genie_sample_id)) %in% samples_per_patient)){
+  stop("Some samples in export file are not in selected samples")
+}
+
 print("output and upload")
 # output and upload ----------------------------
 write.csv(patient_output,file = output_file_name,quote = TRUE,row.names = FALSE,na = "")

--- a/scripts/case_selection/export_bpc_selected_cases.R
+++ b/scripts/case_selection/export_bpc_selected_cases.R
@@ -106,7 +106,7 @@ temp <- sapply(strsplit(temp, '[, ]+'), function(x) toString(shQuote(x)))
 # download clinical data
 # sample clinical data
 clinical_sample <- read.delim(synGet(clinical_sample_id, downloadFile = TRUE, followLink = TRUE)$path, skip = 4, header = TRUE)
-clinical_sample <- sqldf(paste("SELECT * FROM clinical_sample where SAMPLE_ID in (",temp,")",sep = ""))
+clinical_sample <- sqldf("SELECT * FROM clinical_sample")
 
 # patient clinical data
 clinical_patient <- read.delim(synGet(clinical_patient_id, downloadFile = TRUE, followLink = TRUE)$path, skip = 4, header = TRUE)

--- a/scripts/case_selection/perform_case_selection.R
+++ b/scripts/case_selection/perform_case_selection.R
@@ -273,12 +273,22 @@ get_eligible_cohort <- function(x, randomize = T) {
   mod$flag_eligible <- apply(x[,col_flags], 1, all)
   
   # determine eligible samples (all flags TRUE)
-  eligible <- as.data.frame(mod %>%
-    filter(flag_eligible) %>% 
-    group_by(PATIENT_ID) %>%
-    summarize(SAMPLE_IDS = paste0(SAMPLE_ID, collapse = ";"))%>%
-    select(PATIENT_ID, SAMPLE_IDS))
+  # eligible <- as.data.frame(mod %>%
+  #   filter(flag_eligible) %>%
+  #   group_by(PATIENT_ID) %>%
+  #   summarize(SAMPLE_IDS = paste0(SAMPLE_ID, collapse = ";"))%>%
+  #   select(PATIENT_ID, SAMPLE_IDS))
   
+  eligible <- mod %>%
+    group_by(PATIENT_ID) %>%
+    summarize(
+      SAMPLE_IDS = paste0(SAMPLE_ID, collapse = ";"),
+      all_false = all(!flag_eligible)  # Check if all flags are FALSE
+    ) %>%
+    filter(!all_false) %>%  # Filter out patients where all flags are FALSE
+    select(PATIENT_ID, SAMPLE_IDS) %>%
+    as.data.frame()
+
   if (nrow(eligible) == 0) {
     stop(glue("Number of eligible samples for phase {phase} {site} {cohort} is 0.  Please revise eligibility criteria."))
   }

--- a/subworkflows/case_selection_workflow.nf
+++ b/subworkflows/case_selection_workflow.nf
@@ -8,27 +8,28 @@ params.cohort = "NSCLC"
 // center
 params.center = "DFCI"
 params.production = false
-params.bpc_input = "syn53294194"
-params.bpc_output = "syn62147862"
 export_phase = "phase " + params.phase
+
+if (params.production) {
+    bpc_output = "syn20798271"
+} else {
+    bpc_output = "syn62147862"
+}
 
 // import modules
 include { run_workflow_case_selection } from '../modules/run_workflow_case_selection'
 include { run_export_bpc_selected_cases } from '../modules/run_export_bpc_selected_cases'
 
 workflow export_bpc_cases {
-    // run_workflow_case_selection(params.phase, params.cohort, params.center, params.production)
-    run_export_bpc_selected_cases(params.bpc_input, params.bpc_output, export_phase, params.cohort, params.center)
+    run_export_bpc_selected_cases(params.bpc_input, bpc_output, export_phase, params.cohort, params.center)
 }
-
 
 workflow case_selection {
     run_workflow_case_selection(params.phase, params.cohort, params.center, params.production)
-    // run_export_bpc_selected_cases(params.bpc_input, params.bpc_output, params.phase, params.cohort, params.center)
 }
 
 // TODO: This is commented out because the two steps currently don't connect together in a smooth way
 // workflow case_selection_workflow {
 //     run_workflow_case_selection(params.phase, params.cohort, params.center, params.production)
-//     run_export_bpc_selected_cases(params.bpc_input, params.bpc_output, params.phase, params.cohort, params.center)
+//     run_export_bpc_selected_cases(params.bpc_input, bpc_output, params.phase, params.cohort, params.center)
 // }


### PR DESCRIPTION
**Problem**
If a patient has one sample that passes the case selection criteria, then all of its samples should be included.  The code currently does not do that

**Solution**
*  Include all samples of patients that have at least one sample that pass the criteria
* Add validation code that runs just after the code

**Bonus**
* Allow workflow to run smoother by removing a parameter

# Validation
## case selection

The case_selection.csv has 263 patients and 282 samples.  If you look below the export file has 254 patients and 271 samples.  So why the difference in samples and patients?

* Case selection currently uses unfiltered database tables and export uses consortium release.  There are 9 patients filtered out (10 samples) and 1 sample filtered out (SEQ_DATE filter).  This brings the total to 11 samples filtered out which brings the samples to 271!


## Export code
[1] "Missing patients from consortium release: 9"
[1] "map data for each instrument"
[1] "recode"
[1] "instrument cancer panel test"
[1] "export file N unique patients 254"
[1] "export file N unique samples 271"
[1] "N Unique selected patients 263"
[1] "N Unique selected samples 271"

So The export file has 254 patients and 271 samples.  The sample counts match but the patient counts don't, but there are 9 missing patients.  263-9 = 254

- [ ] Need to add validation for case selection