### PR TITLE
[GEN-1481, GEN-1488] Add validation for GENIE BPC / hardcode 17.2-consortium for export code

### DIFF
--- a/scripts/case_selection/export_bpc_selected_cases.R
+++ b/scripts/case_selection/export_bpc_selected_cases.R
@@ -183,6 +183,33 @@ sample_info_list <- lapply(samples_per_patient,function(x){
 
 sample_info_df <- rbind.fill(sample_info_list)
 patient_output <- rbind.fill(patient_output,sample_info_df)
+
+print("validate output")
+n_unique_patients_export = length(unique(sample_info_df$record_id))
+n_unique_samples_export = length(unique(sample_info_df$cpt_genie_sample_id))
+n_unique_selected_patients = length(unique(selected_cases))
+n_unique_selected_samples = length(unique(samples_per_patient))
+n_missing_patients = length(missing_patients)
+
+print(paste("export file N unique patients", n_unique_patients_export))
+print(paste("export file N unique samples", n_unique_samples_export))
+print(paste("N Unique selected patients", n_unique_selected_patients))
+print(paste("N Unique selected samples", n_unique_selected_samples))
+
+if (n_unique_samples_export != n_unique_selected_samples){
+  stop("Number of unique samples in export file does not match number of selected samples")
+}
+if (n_unique_patients_export != n_unique_selected_patients - n_missing_patients){
+  stop("Number of unique patients in export file does not match number of selected patients")
+}
+if (!all(patient_output$record_id %in% selected_cases)){
+  stop("Some patients in export file are not in selected patients")
+}
+# There is expected NA, because the export file is technically two csvs concatenated together
+if (!all(unique(na.omit(patient_output$cpt_genie_sample_id)) %in% samples_per_patient)){
+  stop("Some samples in export file are not in selected samples")
+}
+
 print("output and upload")
 # output and upload ----------------------------
 write.csv(patient_output,file = output_file_name,quote = TRUE,row.names = FALSE,na = "")

--- a/scripts/case_selection/export_bpc_selected_cases.R
+++ b/scripts/case_selection/export_bpc_selected_cases.R
@@ -77,9 +77,9 @@ if (!is.element(site, site_option)) {
 # setup ----------------------------
 print("get clinical data")
 # clinical data
-# HACK: always use the most recent consortium release at the time of execution of this code
-clinical_sample_id <- "syn9734573"
-clinical_patient_id <- "syn9734568"
+# This is hardcoded 17.2-consortium release
+clinical_sample_id <- "syn62173557"
+clinical_patient_id <- "syn62173556"
 
 # mapping tables
 sex_mapping <- synTableQuery("SELECT * FROM syn7434222")$asDataFrame()

--- a/scripts/case_selection/perform_case_selection.R
+++ b/scripts/case_selection/perform_case_selection.R
@@ -410,31 +410,44 @@ if (debug) {
   print(glue("{now(timeOnly = T)}: writing eligibility matrix and case selection to file..."))
 }
 
+case_selection_samples <- extract_sample_ids(case_selection$SAMPLE_IDS)
+selected_samples <- extract_sample_ids(eligible_cohort$SAMPLE_ID)
 
 n_unique_patients_eligible_matrix = length(unique(eligibility_matrix$PATIENT_ID))
 n_unique_samples_eligible_matrix = length(unique(eligibility_matrix$SAMPLE_ID))
+n_unique_patients_case_selection = length(unique(case_selection$PATIENT_ID))
+n_unique_samples_case_selection = length(unique(case_selection_samples))
 n_unique_selected_patients = length(unique(eligible_cohort$PATIENT_ID))
-n_unique_selected_samples = length(unique(eligible_cohort$SAMPLE_ID))
+n_unique_selected_samples = length(unique(selected_samples))
 
 if (debug) {
   print("validation")
-  print(paste("export file N unique patients", n_unique_patients_eligible_matrix))
-  print(paste("export file N unique samples", n_unique_samples_eligible_matrix))
+  print(paste("eligibility matrix file N unique patients", n_unique_patients_eligible_matrix))
+  print(paste("eligibility matrix file N unique samples", n_unique_samples_eligible_matrix))
+  print(paste("case selection file N unique patients", n_unique_patients_case_selection))
+  print(paste("case selection file N unique samples", n_unique_samples_case_selection))
   print(paste("N Unique selected patients", n_unique_selected_patients))
   print(paste("N Unique selected samples", n_unique_selected_samples))
 }
-if (n_unique_samples_eligible_matrix != n_unique_selected_samples){
-  stop("Number of unique samples in eligibility matrix file does not match number of selected samples")
+if (n_unique_samples_case_selection != n_unique_selected_samples){
+  stop("Number of unique samples in case selection file does not match number of selected samples")
 }
-if (n_unique_patients_eligible_matrix != n_unique_selected_patients){
-  stop("Number of unique patients in eligibility matrix file does not match number of selected patients")
+if (n_unique_patients_case_selection != n_unique_selected_patients){
+  stop("Number of unique patients in case selection file does not match number of selected patients")
 }
-if (!all(eligibility_matrix$PATIENT_ID %in% eligibility_matrix$PATIENT_ID)){
-  stop("Some patients in eligibility matrix file are not in selected patients")
+
+if (!all(case_selection$PATIENT_ID %in% eligible_cohort$PATIENT_ID)){
+  stop("Some patients in eligibility matrix file are not in elgibile cohort")
 }
-# There is expected NA, because the export file is technically two csvs concatenated together
-if (!all(eligibility_matrix$SAMPLE_ID %in% eligibility_matrix$SAMPLE_ID)){
-  stop("Some samples in eligibility matrix file are not in selected samples")
+if (!all(case_selection$SAMPLE_IDS %in% eligible_cohort$SAMPLE_ID)){
+  stop("Some samples in eligibility matrix file are not in elgibile cohort")
+}
+
+if (!all(case_selection$PATIENT_ID %in% eligibility_matrix$PATIENT_ID)){
+  stop("Some patients in case selection file are not in eligibility matrix")
+}
+if (!all(case_selection_samples %in% eligibility_matrix$SAMPLE_ID)){
+  stop("Some samples in case selection file are not in eligibility matrix")
 }
 
 

--- a/scripts/case_selection/perform_case_selection.R
+++ b/scripts/case_selection/perform_case_selection.R
@@ -410,6 +410,34 @@ if (debug) {
   print(glue("{now(timeOnly = T)}: writing eligibility matrix and case selection to file..."))
 }
 
+
+n_unique_patients_eligible_matrix = length(unique(eligibility_matrix$PATIENT_ID))
+n_unique_samples_eligible_matrix = length(unique(eligibility_matrix$SAMPLE_ID))
+n_unique_selected_patients = length(unique(eligible_cohort$PATIENT_ID))
+n_unique_selected_samples = length(unique(eligible_cohort$SAMPLE_ID))
+
+if (debug) {
+  print("validation")
+  print(paste("export file N unique patients", n_unique_patients_eligible_matrix))
+  print(paste("export file N unique samples", n_unique_samples_eligible_matrix))
+  print(paste("N Unique selected patients", n_unique_selected_patients))
+  print(paste("N Unique selected samples", n_unique_selected_samples))
+}
+if (n_unique_samples_eligible_matrix != n_unique_selected_samples){
+  stop("Number of unique samples in eligibility matrix file does not match number of selected samples")
+}
+if (n_unique_patients_eligible_matrix != n_unique_selected_patients){
+  stop("Number of unique patients in eligibility matrix file does not match number of selected patients")
+}
+if (!all(eligibility_matrix$PATIENT_ID %in% eligibility_matrix$PATIENT_ID)){
+  stop("Some patients in eligibility matrix file are not in selected patients")
+}
+# There is expected NA, because the export file is technically two csvs concatenated together
+if (!all(eligibility_matrix$SAMPLE_ID %in% eligibility_matrix$SAMPLE_ID)){
+  stop("Some samples in eligibility matrix file are not in selected samples")
+}
+
+
 if (flag_additional) {
   write.csv(added_sam, file = file_add, row.names = F)
 } else {

--- a/scripts/case_selection/shared_fxns.R
+++ b/scripts/case_selection/shared_fxns.R
@@ -206,3 +206,33 @@ get_synapse_entity_data_in_csv <- function(synapse_id,
                    header = header)
   return(data)
 }
+
+
+#' Extract and Combine Unique Sample IDs from a List
+#'
+#' This function takes a list of strings, splits each string by the ';' delimiter,
+#' and combines all the resulting elements into a single list of unique sample IDs.
+#'
+#' @param sample_ids_list A list of strings where each string may contain delimited sample IDs.
+#'
+#' @return A character vector of unique sample IDs.
+#'
+#' @examples
+#' \dontrun{
+#' # Example list of sample IDs
+#' sample_ids <- list("ID1;ID2;ID3", "ID4;ID5", "ID2;ID6")
+#' all_sample_ids <- extract_sample_ids(sample_ids)
+#' print(all_sample_ids)
+#' }
+#'
+#' @export
+extract_sample_ids <- function(sample_ids_list) {
+  all_sample_ids <- list()
+  for (sample_id_str in sample_ids_list) {
+    split_ids <- strsplit(sample_id_str, ";")[[1]]
+    all_sample_ids <- c(all_sample_ids, split_ids)
+  }
+
+  all_sample_ids <- unique(all_sample_ids)
+  return(all_sample_ids)
+}

--- a/scripts/case_selection/workflow_case_selection.R
+++ b/scripts/case_selection/workflow_case_selection.R
@@ -115,7 +115,12 @@ save_to_synapse <- function(path,
 # case selection ----------------------------
 
 # construct eligibility matrices + case lists
-system(glue("Rscript perform_case_selection.R -p {phase} -c {cohort} -s {site}"))
+exit_status <- system(glue("Rscript perform_case_selection.R -p {phase} -c {cohort} -s {site}"))
+
+# Check if the command failed
+if (exit_status != 0) {
+  stop(glue("The command Rscript perform_case_selection.R failed with exit status {exit_status}. Script will terminate."))
+}
 
 if (!flag_additional) {
   # render eligibility report


### PR DESCRIPTION
**Problem**
There isn't any validation of the output data for case selection or export code

**Solution**
Add very basic validation for the data output for the export and case selection code so that we ensure the sample number of patients and samples go in and out.

**Bonus**
* If the Rscript call fails, it will now quit the entire script and not run the Rmd file
* Hardcode 17.2-consortium release sample and patient file

## case list validation
```
[1] "validation"
[1] "eligibility matrix file N unique patients 17781"
[1] "eligibility matrix file N unique samples 18856"
[1] "case selection file N unique patients 263"
[1] "case selection file N unique samples 269"
[1] "N Unique selected patients 263"
[1] "N Unique selected samples 269"
```
* Make sure all samples from eligibility + case selection are part of the main genie cohort
* make sure numbers are equal above

## Export file validation

```
[1] "get clinical data"
[1] "get all samples for selected patients"
[1] "Missing patients from consortium release: 9"
[1] "map data for each instrument"
[1] "recode"
[1] "instrument cancer panel test"
[1] "validate output"
[1] "export file N unique patients 254"
[1] "export file N unique samples 259"
[1] "N Unique selected patients 263"
[1] "N Unique selected samples 259"
```