### PR TITLE
[GEN-1485] Add missing previous input to run_quac_upload_report_error step

### DIFF
--- a/modules/run_quac_upload_report_error.nf
+++ b/modules/run_quac_upload_report_error.nf
@@ -9,6 +9,7 @@ process run_quac_upload_report_error {
    debug true
 
    input:
+   val previous
    val cohort
 
    output:


### PR DESCRIPTION
**Purpose:** `run_quac_upload_report_error` is the step after `update_potential_phi_fields` in the BPC pipeline and was missing the required `previous` parameter to make sure it only runs after `update_potential_phi_fields` step.

**Testing:** Working for [this workflow run](https://tower.sagebionetworks.org/orgs/Sage-Bionetworks/workspaces/genie-bpc-project/watch/42GwL0IKaeG1rr)