### PR TITLE
[GEN-1574] Add merge and decode to staging

### DIFF
--- a/.github/workflows/build-docker-images.yml
+++ b/.github/workflows/build-docker-images.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        module: ["references", "table_updates"] # Define the modules you want to loop through for builds
+        module: ["references", "table_updates", "uploads"] # Define the modules you want to loop through for builds
     env:
       REGISTRY: ghcr.io
       IMAGE_NAME: sage-bionetworks/genie-bpc-pipeline

--- a/main.nf
+++ b/main.nf
@@ -97,7 +97,6 @@ workflow BPC_PIPELINE {
     // validate_data.out.view()
    } else if (params.step == "merge_and_uncode_rca_uploads"){
     merge_and_uncode_rca_uploads("default", ch_cohort, params.production)
-   }
    } else if (params.step == "genie_bpc_pipeline"){
     update_potential_phi_fields_table(ch_comment, params.production)
     run_quac_upload_report_error(update_potential_phi_fields_table.out, ch_cohort)

--- a/main.nf
+++ b/main.nf
@@ -96,12 +96,12 @@ workflow BPC_PIPELINE {
     update_potential_phi_fields_table(ch_comment, params.production)
     // validate_data.out.view()
    } else if (params.step == "merge_and_uncode_rca_uploads"){
-    merge_and_uncode_rca_uploads("default", ch_cohort, params.production)
+    merge_and_uncode_rca_uploads("default", ch_cohort, ch_comment, params.production)
    } else if (params.step == "genie_bpc_pipeline"){
     update_potential_phi_fields_table(ch_comment, params.production)
     run_quac_upload_report_error(update_potential_phi_fields_table.out, ch_cohort)
     run_quac_upload_report_warning(run_quac_upload_report_error.out, ch_cohort, params.production)
-    merge_and_uncode_rca_uploads(run_quac_upload_report_warning.out, ch_cohort, params.production)
+    merge_and_uncode_rca_uploads(run_quac_upload_report_warning.out, ch_cohort, ch_comment, params.production)
     // remove_patients_from_merged(merge_and_uncode_rca_uploads.out, ch_cohort, params.production)
     update_data_table(merge_and_uncode_rca_uploads.out, ch_comment, params.production)
     update_date_tracking_table(update_data_table.out, ch_cohort, ch_comment, params.production)

--- a/main.nf
+++ b/main.nf
@@ -95,6 +95,9 @@ workflow BPC_PIPELINE {
    if (params.step == "update_potential_phi_fields_table") {
     update_potential_phi_fields_table(ch_comment, params.production)
     // validate_data.out.view()
+   } else if (params.step == "merge_and_uncode_rca_uploads"){
+    merge_and_uncode_rca_uploads("default", ch_cohort, params.production)
+   }
    } else if (params.step == "genie_bpc_pipeline"){
     update_potential_phi_fields_table(ch_comment, params.production)
     run_quac_upload_report_error(update_potential_phi_fields_table.out, ch_cohort)

--- a/modules/merge_and_uncode_rca_uploads.nf
+++ b/modules/merge_and_uncode_rca_uploads.nf
@@ -20,13 +20,13 @@ process merge_and_uncode_rca_uploads {
    if (production) {
       """
       cd /usr/local/src/myscripts/
-      Rscript merge_and_uncode_rca_uploads.R -c $cohort -v --production --save_synapse
+      Rscript merge_and_uncode_rca_uploads.R -c $cohort -v --production --save_synapse -c $comment
       """
    }
    else {
       """
       cd /usr/local/src/myscripts/
-      Rscript merge_and_uncode_rca_uploads.R -c $cohort -v --save_synapse
+      Rscript merge_and_uncode_rca_uploads.R -c $cohort -v --save_synapse -c $comment
       """
    }
 }

--- a/modules/merge_and_uncode_rca_uploads.nf
+++ b/modules/merge_and_uncode_rca_uploads.nf
@@ -19,7 +19,7 @@ process merge_and_uncode_rca_uploads {
    if (production) {
       """
       cd /usr/local/src/myscripts/
-      Rscript merge_and_uncode_rca_uploads.R -c $cohort -u -v
+      Rscript merge_and_uncode_rca_uploads.R -c $cohort -v --production
       """
    }
    else {

--- a/modules/merge_and_uncode_rca_uploads.nf
+++ b/modules/merge_and_uncode_rca_uploads.nf
@@ -3,7 +3,7 @@ Merge and uncode REDcap export data files.
 */
 process merge_and_uncode_rca_uploads {
 
-   container 'sagebionetworks/genie-bpc-pipeline-uploads'
+   container "$params.uploads_docker"
    secret 'SYNAPSE_AUTH_TOKEN'
    debug true
 

--- a/modules/merge_and_uncode_rca_uploads.nf
+++ b/modules/merge_and_uncode_rca_uploads.nf
@@ -20,13 +20,13 @@ process merge_and_uncode_rca_uploads {
    if (production) {
       """
       cd /usr/local/src/myscripts/
-      Rscript merge_and_uncode_rca_uploads.R -c $cohort -v --production --save_synapse -cmt $comment
+      Rscript merge_and_uncode_rca_uploads.R -c $cohort -v --production --save_synapse --comment $comment
       """
    }
    else {
       """
       cd /usr/local/src/myscripts/
-      Rscript merge_and_uncode_rca_uploads.R -c $cohort -v --save_synapse -cmt $comment
+      Rscript merge_and_uncode_rca_uploads.R -c $cohort -v --save_synapse --comment $comment
       """
    }
 }

--- a/modules/merge_and_uncode_rca_uploads.nf
+++ b/modules/merge_and_uncode_rca_uploads.nf
@@ -19,13 +19,13 @@ process merge_and_uncode_rca_uploads {
    if (production) {
       """
       cd /usr/local/src/myscripts/
-      Rscript merge_and_uncode_rca_uploads.R -c $cohort -v --production
+      Rscript merge_and_uncode_rca_uploads.R -c $cohort -v --production --save_synapse
       """
    }
    else {
       """
       cd /usr/local/src/myscripts/
-      Rscript merge_and_uncode_rca_uploads.R -c $cohort -v
+      Rscript merge_and_uncode_rca_uploads.R -c $cohort -v --save_synapse
       """
    }
 }

--- a/modules/merge_and_uncode_rca_uploads.nf
+++ b/modules/merge_and_uncode_rca_uploads.nf
@@ -10,6 +10,7 @@ process merge_and_uncode_rca_uploads {
    input:
    val previous
    val cohort
+   val comment
    val production
 
    output:

--- a/modules/merge_and_uncode_rca_uploads.nf
+++ b/modules/merge_and_uncode_rca_uploads.nf
@@ -20,13 +20,13 @@ process merge_and_uncode_rca_uploads {
    if (production) {
       """
       cd /usr/local/src/myscripts/
-      Rscript merge_and_uncode_rca_uploads.R -c $cohort -v --production --save_synapse -c $comment
+      Rscript merge_and_uncode_rca_uploads.R -c $cohort -v --production --save_synapse -cmt $comment
       """
    }
    else {
       """
       cd /usr/local/src/myscripts/
-      Rscript merge_and_uncode_rca_uploads.R -c $cohort -v --save_synapse -c $comment
+      Rscript merge_and_uncode_rca_uploads.R -c $cohort -v --save_synapse -cmt $comment
       """
    }
 }

--- a/nextflow.config
+++ b/nextflow.config
@@ -53,6 +53,7 @@ profiles {
 		params {
 			// docker image parameters, see nextflow_schema.json for details
 			references_docker = "sagebionetworks/genie-bpc-pipeline-references"
+			uploads_docker = "sagebionetworks/genie-bpc-pipeline-uploads"
 		}
 	}
 }

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -50,6 +50,7 @@
                     "description": "Available BPC steps",
                     "enum": [
                         "update_potential_phi_fields_table",
+                        "merge_and_uncode_rca_uploads",
                         "genie_bpc_pipeline"
                     ]
                 },

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -57,6 +57,10 @@
                     "type": "string",
                     "description": "Name of docker to use in processes in scripts/references"
                 },
+                "uploads_docker":{
+                    "type": "string",
+                    "description": "Name of docker to use in processes in scripts/uploads"
+                },
                 "schema_ignore_params": {
                     "type": "string",
                     "description": "Put parameters to ignore for validation here separated by comma",

--- a/scripts/uploads/Dockerfile
+++ b/scripts/uploads/Dockerfile
@@ -1,21 +1,34 @@
-FROM r-base:4.0.0
+FROM rstudio/r-base:4.0-bullseye
 
+# Set working directory
 WORKDIR /usr/local/src/myscripts
 
+# Set environment variable for renv version
 ENV RENV_VERSION 0.14.0
 
-RUN rm /etc/apt/apt.conf.d/default
-RUN apt-get update -y
-RUN apt-get install -y dpkg-dev zlib1g-dev libssl-dev libffi-dev
-# procps is required for nextflow tower
-RUN apt-get install -y curl libcurl4-openssl-dev procps
-RUN R -e "install.packages('synapser', repos=c('http://ran.synapse.org', 'http://cran.fhcrc.org'))"
+# Update apt-get and install system dependencies (only install required)
+RUN apt-get update -y && \
+    apt-get install -y --no-install-recommends \ 
+    dpkg-dev zlib1g-dev libssl-dev libffi-dev \
+    libcurl4-openssl-dev curl procps && \
+    apt-get clean && \
+    rm -rf /var/lib/apt/lists/*
 
+# Install R packages including remotes and renv
+RUN R -e "install.packages('remotes', repos = 'https://cloud.r-project.org')" && \
+    R -e "remotes::install_github('rstudio/renv', ref = '${RENV_VERSION}')" || true
+
+# Install synapser with specific version
+RUN R -e "remotes::install_version('synapser', version = '0.11.7', repos = c('http://ran.synapse.org', 'http://cran.fhcrc.org'))"
+
+# Set Python environment variable for R
 ENV PYTHON /usr/local/lib/R/site-library/PythonEmbedInR/bin/python3.6
 
-RUN R -e "install.packages('remotes', repos = c(CRAN = 'https://cloud.r-project.org'))"
-RUN R -e "remotes::install_github('rstudio/renv@${RENV_VERSION}')"
+# Copy only renv.lock first to leverage docker cache for dependencies
+COPY renv.lock renv.lock
 
-COPY . .
-
+# Restore R environment with renv
 RUN R -e "renv::restore()"
+
+# Copy the local project files into the container
+COPY . .

--- a/scripts/uploads/README.md
+++ b/scripts/uploads/README.md
@@ -45,7 +45,7 @@ Usage: merge_and_uncode_rca_uploads.R [options]
 Options:
         -c COHORT, --cohort=COHORT
                 BPC cohort
-
+        
         -u, --save_synapse
                 Save output to Synapse
 
@@ -54,11 +54,19 @@ Options:
 
         -h, --help
                 Show this help message and exit
+
+        --production
+                Whether to run in production mode or not (staging mode).
 ```
 
-Example run: 
+Example run (staging run):
 ```
 Rscript merge_and_uncode_rca_uploads.R -c NSCLC -u -a $SYNAPSE_AUTH_TOKEN
+```
+
+Example run (production run):
+```
+Rscript merge_and_uncode_rca_uploads.R -c NSCLC -u -a $SYNAPSE_AUTH_TOKEN --production
 ```
 
 ## Usage: remove patient IDs from a REDCap formatted file
@@ -99,4 +107,44 @@ Options:
 Example run: 
 ```
 Rscript remove_patients_from_merged.R -i syn23285494 -c NSCLC -r syn29266682 -v
+```
+
+## Running tests
+There are unit tests under `scripts/uploads/tests`.
+
+1. Please pull and run the docker image associated with this module from [here](https://github.com/Sage-Bionetworks/genie-bpc-pipeline/pkgs/container/genie-bpc-pipeline) into your EC2/local.
+
+You can also pull the production docker:
+
+```bash
+git pull sagebionetworks/genie-bpc-pipeline-uploads
+```
+
+```bash
+docker run -d --name <nickname_for_container> <container_name> /bin/bash -c "while true; do sleep 1; done"
+```
+
+2. Do anything you need to do to the container (e.g: copy current local changes)
+
+```bash
+docker cp ./. test_container:/usr/local/src/myscripts
+```
+
+3. Execute container into a bash session
+
+```bash
+docker exec -it <nickname_for_container> /bin/bash
+```
+
+4. Install the `mockery` and `testthat` packages:
+
+```bash
+R -e "remotes::install_cran('testthat')"
+```
+
+5. Run the following in a R session:
+
+```R
+library(testthat)
+test_dir("/usr/local/src/myscripts/tests")
 ```

--- a/scripts/uploads/README.md
+++ b/scripts/uploads/README.md
@@ -2,6 +2,10 @@
 [![automated](https://img.shields.io/docker/cloud/automated/sagebionetworks/genie-bpc-pipeline-uploads)](https://hub.docker.com/r/sagebionetworks/genie-bpc-pipeline-uploads)
 ![status](https://img.shields.io/docker/cloud/build/sagebionetworks/genie-bpc-pipeline-uploads)
 
+## Setup
+
+You will want to run on an EC2 instance with docker installed.
+
 ## Installation
 
 Clone this repository and navigate to the directory:
@@ -10,10 +14,42 @@ git clone git@github.com:Sage-Bionetworks/genie-bpc-pipeline.git
 cd genie-bpc-pipeline/bpc/uploads/
 ```
 
-Install all required R packages:
+### Local installation
+
+Install all required R packages by copying and running the commands in the Dockerfile
+at `scripts/uploads/Dockerfile` except for the last step which is copying your current repo.
+
+### Docker
+
+Alternatively, you can pull the docker image associated with this module from [here](https://github.com/Sage-Bionetworks/genie-bpc-pipeline/pkgs/container/genie-bpc-pipeline) into your EC2.
+
+You can also pull the production docker:
+
+```bash
+git pull sagebionetworks/genie-bpc-pipeline-uploads
 ```
-R -e 'renv::restore()'
+
+To run the docker image:
+
+1. Run the docker
+
+```bash
+docker run -d --name <nickname_for_container> <container_name> /bin/bash -c "while true; do sleep 1; done"
 ```
+
+2. **Optional.** Do anything you need to do to the container (e.g: copy current local changes to the docker)
+
+```bash
+docker cp ./. test_container:/usr/local/src/myscripts
+```
+
+3. Execute container into a bash session
+
+```bash
+docker exec -it <nickname_for_container> /bin/bash
+```
+
+Now you can run the script commands
 
 ## Synapse credentials
 
@@ -112,37 +148,13 @@ Rscript remove_patients_from_merged.R -i syn23285494 -c NSCLC -r syn29266682 -v
 ## Running tests
 There are unit tests under `scripts/uploads/tests`.
 
-1. Please pull and run the docker image associated with this module from [here](https://github.com/Sage-Bionetworks/genie-bpc-pipeline/pkgs/container/genie-bpc-pipeline) into your EC2/local.
-
-You can also pull the production docker:
-
-```bash
-git pull sagebionetworks/genie-bpc-pipeline-uploads
-```
-
-```bash
-docker run -d --name <nickname_for_container> <container_name> /bin/bash -c "while true; do sleep 1; done"
-```
-
-2. Do anything you need to do to the container (e.g: copy current local changes)
-
-```bash
-docker cp ./. test_container:/usr/local/src/myscripts
-```
-
-3. Execute container into a bash session
-
-```bash
-docker exec -it <nickname_for_container> /bin/bash
-```
-
-4. Install the `mockery` and `testthat` packages:
+1. Install the `mockery` and `testthat` packages via the command line:
 
 ```bash
 R -e "remotes::install_cran('testthat')"
 ```
 
-5. Run the following in a R session:
+2. Run the following in a R session in your EC2:
 
 ```R
 library(testthat)

--- a/scripts/uploads/config.yaml
+++ b/scripts/uploads/config.yaml
@@ -10,7 +10,8 @@ synapse:
     type: table
     description: PRISSMM formatted data dictionaries for REDCap
   rca_files: 
-    id: syn23286928
+    production_id: syn23286928
+    staging_id: syn63887337
     name: curated
     type: folder
     description: REDCap academic formatted files of merged BPC data ready for import to Synapse tables

--- a/scripts/uploads/merge_and_uncode_rca_uploads.R
+++ b/scripts/uploads/merge_and_uncode_rca_uploads.R
@@ -487,12 +487,22 @@ get_irr <- function(data) {
   return(irr)
 }
 
-save_to_synapse <- function(path, parent_id, file_name = NA, prov_name = NA, prov_desc = NA, prov_used = NA, prov_exec = NA) {
+#' Stores the file, version comment and provenance to Synapse
+#' @param path (string) name of cohort
+#' @param parent_id (string) whether we are running in production env or staging env
+#' @param comment (string) some sort of comment about the new version of the file 
+#' @param file_name (string) file name
+#' @param prov_name (string) name of provenance
+#' @param prov_desc (string) provenance description
+#' @param prov_used (string) url/link to provenance used
+#' @param prov_exec (string) url/link to what was used to execute provenance
+save_to_synapse <- function(path, parent_id, comment, file_name = NA, prov_name = NA, prov_desc = NA, prov_used = NA, prov_exec = NA) {
   
   if (is.na(file_name)) {
     file_name = path
   } 
   file <- File(path = path, parentId = parent_id, name = file_name)
+  file$properties$versionComment <- comment
   
   if (!is.na(prov_name) || !is.na(prov_desc) || !is.na(prov_used) || !is.na(prov_exec)) {
     act <- Activity(name = prov_name,
@@ -635,7 +645,9 @@ get_output_folder_id <- function(config, environment){
 #' Remove leading and trailing whitespace from a string.
 #' @param cohort (string) name of cohort
 #' @param environment (string) whether we are running in production env or staging env
-save_output_synapse <- function(cohort, environment) {
+#' @param comment (string) some sort of comment about the new version of the file 
+#'  related to cohort run
+save_output_synapse <- function(cohort, environment, comment) {
   
   parent_id <- get_output_folder_id(config, environment)
   file_output_pri <- get_pri_file_name(cohort)
@@ -647,6 +659,7 @@ save_output_synapse <- function(cohort, environment) {
   save_to_synapse(path = file_output_pri,
                   file_name = gsub(pattern = ".csv|.tsv", replacement = "", x = file_output_pri),
                   parent_id = parent_id,
+                  comment = comment,
                   prov_name = "BPC non-IRR upload data",
                   prov_desc = "Merged and uncoded BPC upload data from sites academic REDCap instances with IRR cases removed",
                   prov_used = c(as.character(unlist(config$upload[[cohort]])), 
@@ -658,6 +671,7 @@ save_output_synapse <- function(cohort, environment) {
     save_to_synapse(path = file_output_irr,
                     file_name = gsub(pattern = ".csv|.tsv", replacement = "", x = file_output_irr),
                     parent_id = parent_id,
+                    comment = comment,
                     prov_name = "BPC IRR upload data",
                     prov_desc = "Merged and uncoded BPC upload IRR case data from sites academic REDCap instances",
                     prov_used = c(as.character(unlist(config$upload[[cohort]])), 
@@ -690,7 +704,9 @@ main <- function(){
     make_option(c("--production"), action="store_true", default = FALSE, 
                 help="Whether to run in production mode or not (staging mode)."),
     make_option(c("-v", "--verbose"), action="store_true", default = FALSE, 
-                help="Print out verbose output on script progress")
+                help="Print out verbose output on script progress"),
+    make_option(c("-c", "--comment"), type = "character",
+              help="Comment for new table snapshot version. This must be unique and is tied to the cohort run.")
   )
   opt <- parse_args(OptionParser(option_list=option_list))
 
@@ -792,7 +808,7 @@ main <- function(){
         print(glue("{now(timeOnly = T)}: Saving uncoded data to Synapse..."))
       }
       
-      save_output_synapse(cohort, environment = env)
+      save_output_synapse(cohort, environment = env, comment = opt$comment)
     }
     
     # clean up for memory

--- a/scripts/uploads/merge_and_uncode_rca_uploads.R
+++ b/scripts/uploads/merge_and_uncode_rca_uploads.R
@@ -705,7 +705,7 @@ main <- function(){
                 help="Whether to run in production mode or not (staging mode)."),
     make_option(c("-v", "--verbose"), action="store_true", default = FALSE, 
                 help="Print out verbose output on script progress"),
-    make_option(c("-c", "--comment"), type = "character",
+    make_option(c("-cmt", "--comment"), type = "character",
               help="Comment for new table snapshot version. This must be unique and is tied to the cohort run.")
   )
   opt <- parse_args(OptionParser(option_list=option_list))

--- a/scripts/uploads/merge_and_uncode_rca_uploads.R
+++ b/scripts/uploads/merge_and_uncode_rca_uploads.R
@@ -687,7 +687,7 @@ main <- function(){
                 help="Save output to Synapse"),
     make_option(c("-a", "--synapse_auth"), type = "character", default = NA,
                 help="Path to .synapseConfig file or Synapse PAT (default: normal synapse login behavior)"),
-    make_option(c("-p", "--production"), action="store_true", default = FALSE, 
+    make_option(c("--production"), action="store_true", default = FALSE, 
                 help="Whether to run in production mode or not (staging mode)."),
     make_option(c("-v", "--verbose"), action="store_true", default = FALSE, 
                 help="Print out verbose output on script progress")

--- a/scripts/uploads/merge_and_uncode_rca_uploads.R
+++ b/scripts/uploads/merge_and_uncode_rca_uploads.R
@@ -702,8 +702,10 @@ main <- function(){
             msg = "Usage: Rscript merge_and_uncode_rca_uploads.R -h")
 
   if (opt$production){
+    print(glue("Running in production mode"))
     env <- "production"
   } else {
+    print(glue("Running in staging mode"))
     env <- "staging"
   }
 

--- a/scripts/uploads/merge_and_uncode_rca_uploads.R
+++ b/scripts/uploads/merge_and_uncode_rca_uploads.R
@@ -705,7 +705,7 @@ main <- function(){
                 help="Whether to run in production mode or not (staging mode)."),
     make_option(c("-v", "--verbose"), action="store_true", default = FALSE, 
                 help="Print out verbose output on script progress"),
-    make_option(c("-cmt", "--comment"), type = "character",
+    make_option(c("--comment"), type = "character",
               help="Comment for new table snapshot version. This must be unique and is tied to the cohort run.")
   )
   opt <- parse_args(OptionParser(option_list=option_list))

--- a/scripts/uploads/merge_and_uncode_rca_uploads.R
+++ b/scripts/uploads/merge_and_uncode_rca_uploads.R
@@ -488,8 +488,8 @@ get_irr <- function(data) {
 }
 
 #' Stores the file, version comment and provenance to Synapse
-#' @param path (string) name of cohort
-#' @param parent_id (string) whether we are running in production env or staging env
+#' @param path (string) local filepath of the output
+#' @param parent_id (string) synapse id of the output folder to save to
 #' @param comment (string) some sort of comment about the new version of the file 
 #' @param file_name (string) file name
 #' @param prov_name (string) name of provenance
@@ -502,20 +502,17 @@ save_to_synapse <- function(path, parent_id, comment, file_name = NA, prov_name 
     file_name = path
   } 
   file <- File(path = path, parentId = parent_id, name = file_name)
+  file$versionComment <- comment
   
   if (!is.na(prov_name) || !is.na(prov_desc) || !is.na(prov_used) || !is.na(prov_exec)) {
     act <- Activity(name = prov_name,
                     description = prov_desc,
                     used = prov_used,
                     executed = prov_exec)
-    file_id <- synStore(file, activity = act)$properties$id
+    synStore(file, activity = act)
   } else {
-    file_id <- synStore(file)$properties$id
+    synStore(file)
   }
-  file_no_comment <- synGet(file_id, downloadFile=FALSE)
-  file_no_comment$versionComment <- comment
-  synStore(file_no_comment)
-  
   return(T)
 }
 

--- a/scripts/uploads/merge_and_uncode_rca_uploads.R
+++ b/scripts/uploads/merge_and_uncode_rca_uploads.R
@@ -502,18 +502,19 @@ save_to_synapse <- function(path, parent_id, comment, file_name = NA, prov_name 
     file_name = path
   } 
   file <- File(path = path, parentId = parent_id, name = file_name)
-  file$properties$versionComment <- comment
   
   if (!is.na(prov_name) || !is.na(prov_desc) || !is.na(prov_used) || !is.na(prov_exec)) {
     act <- Activity(name = prov_name,
                     description = prov_desc,
                     used = prov_used,
                     executed = prov_exec)
-    file <- synStore(file, activity = act)
+    file_id <- synStore(file, activity = act)$properties$id
   } else {
-    file <- synStore(file)
+    file_id <- synStore(file)$properties$id
   }
-  
+  file_no_comment <- synGet(file_id, downloadFile=FALSE)
+  file_no_comment$versionComment <- comment
+  synStore(file_no_comment)
   
   return(T)
 }

--- a/scripts/uploads/merge_and_uncode_rca_uploads.R
+++ b/scripts/uploads/merge_and_uncode_rca_uploads.R
@@ -5,9 +5,13 @@
 
 # pre-setup ----------------------------
 
-library(optparse)
-library(yaml)
+library(dplyr)
 library(glue)
+library(lubridate)
+library(optparse)
+library(synapser)
+library(yaml)
+
 
 waitifnot <- function(cond, msg) {
   if (!cond) {
@@ -21,7 +25,7 @@ waitifnot <- function(cond, msg) {
   }
 }
 
-# user input ----------------------------
+# globals ----------------------------
 
 workdir <- "."
 if (!file.exists("config.yaml")) {
@@ -29,47 +33,7 @@ if (!file.exists("config.yaml")) {
 }
 
 config <- read_yaml(glue("{workdir}/config.yaml"))
-cohorts <- names(config$upload)
-cohorts_str <- paste0(cohorts, collapse = ", ")
 
-option_list <- list( 
-  make_option(c("-c", "--cohort"), type = "character",
-              help=glue("BPC cohort (choices: {cohorts_str}, {config$misc$all})")),
-  make_option(c("-u", "--save_synapse"), action="store_true", default = FALSE, 
-              help="Save output to Synapse"),
-  make_option(c("-a", "--synapse_auth"), type = "character", default = NA,
-              help="Path to .synapseConfig file or Synapse PAT (default: normal synapse login behavior)"),
-  make_option(c("-v", "--verbose"), action="store_true", default = FALSE, 
-              help="Print out verbose output on script progress")
-)
-opt <- parse_args(OptionParser(option_list=option_list))
-
-cohort_input <- opt$cohort
-save_on_synapse <- opt$save_synapse
-auth <- opt$synapse_auth
-debug <- opt$verbose
-waitifnot(!is.null(opt$cohort),
-          msg = "Usage: Rscript merge_and_uncode_rca_uploads.R -h")
-
-# setup ----------------------------
-
-tic = as.double(Sys.time())
-
-library(synapser)
-library(dplyr)
-library(lubridate)
-
-# check user input --------------------
-
-waitifnot(is.element(cohort_input, c(cohorts, config$misc$all)), 
-            msg = glue("Error: cohort '{cohort_input}' invalid.  Valid values: {cohorts_str}."))
-
-waitifnot(is.element(save_on_synapse, c(T, F)), 
-          msg = glue("Error: save_on_synapse value '{args[3]}' invalid.  Valid values: TRUE or FALSE."))
-
-if (cohort_input == config$misc$all) {
-  cohort_input = cohorts
-}
 
 # functions ----------------------------
 
@@ -659,10 +623,21 @@ write_output_locally <- function(cohort, data_pri, data_irr) {
   return(files_output)
 }
 
+
+#' Gets the synapse folder id for the outputs of this step
+#' @param cohort (string) name of cohort
+#' @param environment (string) whether we are running in production env or staging env
+get_output_folder_id <- function(config, environment){
+  return(config$synapse$rca_files[[glue(environment, "_id")]])
+}
+
 #' Write to Synapse and clean up
-save_output_synapse <- function(cohort) {
+#' Remove leading and trailing whitespace from a string.
+#' @param cohort (string) name of cohort
+#' @param environment (string) whether we are running in production env or staging env
+save_output_synapse <- function(cohort, environment) {
   
-  parent_id <- config$synapse$rca_files$id
+  parent_id <- get_output_folder_id(config, environment)
   file_output_pri <- get_pri_file_name(cohort)
   file_output_irr <- get_irr_file_name(cohort)
   synid_dd <- get_bpc_synid_prissmm(synid_table_prissmm = config$synapse$prissmm$id, 
@@ -698,90 +673,143 @@ save_output_synapse <- function(cohort) {
   }
 }
 
-# synapse login -------------------
-
-status <- synLogin(auth = auth)
-
 # main ----------------------------
 
-if (debug) {
-  print(glue("{now(timeOnly = T)}: Reading global response set..."))
-}
+main <- function(){
 
-grs <- read.csv(synGet(config$synapse$grs$id)$path, 
-                sep = ",", 
-                stringsAsFactors = F,
-                check.names = F,
-                na.strings = c(""))
+  cohorts <- names(config$upload)
+  cohorts_str <- paste0(cohorts, collapse = ", ")
 
-# for each user-specified cohort
-for (cohort in cohort_input) {
-  
-  if (debug) {
-    print(glue("{now(timeOnly = T)}: Merging and uncoding data for cohort {cohort} -------------------"))
-    print(glue("{now(timeOnly = T)}: Reading data dictionary..."))
+  option_list <- list( 
+    make_option(c("-c", "--cohort"), type = "character",
+                help=glue("BPC cohort (choices: {cohorts_str}, {config$misc$all})")),
+    make_option(c("-u", "--save_synapse"), action="store_true", default = FALSE, 
+                help="Save output to Synapse"),
+    make_option(c("-a", "--synapse_auth"), type = "character", default = NA,
+                help="Path to .synapseConfig file or Synapse PAT (default: normal synapse login behavior)"),
+    make_option(c("-p", "--production"), action="store_true", default = FALSE, 
+                help="Whether to run in production mode or not (staging mode)."),
+    make_option(c("-v", "--verbose"), action="store_true", default = FALSE, 
+                help="Print out verbose output on script progress")
+  )
+  opt <- parse_args(OptionParser(option_list=option_list))
+
+  cohort_input <- opt$cohort
+  save_on_synapse <- opt$save_synapse
+  auth <- opt$synapse_auth
+  debug <- opt$verbose
+  waitifnot(!is.null(opt$cohort),
+            msg = "Usage: Rscript merge_and_uncode_rca_uploads.R -h")
+
+  if (opt$production){
+    env <- "production"
+  } else {
+    env <- "staging"
   }
-  
-  dd <- get_data_dictionary(cohort)
-  
-  if (debug) {
-    print(glue("{now(timeOnly = T)}: Reading data uploads..."))
+
+  # setup ----------------------------
+
+  tic = as.double(Sys.time())
+
+  # check user input --------------------
+
+  waitifnot(is.element(cohort_input, c(cohorts, config$misc$all)), 
+              msg = glue("Error: cohort '{cohort_input}' invalid.  Valid values: {cohorts_str}."))
+
+  waitifnot(is.element(save_on_synapse, c(T, F)), 
+            msg = glue("Error: save_on_synapse value '{args[3]}' invalid.  Valid values: TRUE or FALSE."))
+
+  if (cohort_input == config$misc$all) {
+    cohort_input = cohorts
   }
-  
-  data_upload <- get_data_uploads(cohort)
-  
+  # synapse login
+  status <- synLogin(auth = auth)
+
   if (debug) {
-    print(glue("{now(timeOnly = T)}: Merging data uploads..."))
+    print(glue("{now(timeOnly = T)}: Reading global response set..."))
   }
-  
-  # merge
-  coded <- merge_datasets(data_upload, cohort)
-  
-  if (debug) {
-    print(glue("{now(timeOnly = T)}: Uncoding data uploads..."))
-  }
-  
-  # uncode
-  uncoded <- uncode_data(df_coded = coded, 
-                         dd = dd,
-                         grs = grs)
-  
-  if (debug) {
-    print(glue("{now(timeOnly = T)}: Formatting uncoded data..."))
-  }
-  
-  # format data
-  uncoded_formatted <- format_rca(uncoded, dd = dd)
-  
-  # separate IRR from non-IRR cases
-  data_pri <- remove_irr(uncoded_formatted)
-  data_irr <- get_irr(uncoded_formatted)
-  
-  if (debug) {
-    print(glue("{now(timeOnly = T)}: Writing uncoded data to file locally..."))
-  }
-  
-  write_output_locally(cohort, data_pri, data_irr)
-  
-  if (save_on_synapse) {
+
+  grs <- read.csv(synGet(config$synapse$grs$id)$path, 
+                  sep = ",", 
+                  stringsAsFactors = F,
+                  check.names = F,
+                  na.strings = c(""))
+
+  # for each user-specified cohort
+  for (cohort in cohort_input) {
     
     if (debug) {
-      print(glue("{now(timeOnly = T)}: Saving uncoded data to Synapse..."))
+      print(glue("{now(timeOnly = T)}: Merging and uncoding data for cohort {cohort} -------------------"))
+      print(glue("{now(timeOnly = T)}: Reading data dictionary..."))
     }
     
-    save_output_synapse(cohort)
+    dd <- get_data_dictionary(cohort)
+    
+    if (debug) {
+      print(glue("{now(timeOnly = T)}: Reading data uploads..."))
+    }
+    
+    data_upload <- get_data_uploads(cohort)
+    
+    if (debug) {
+      print(glue("{now(timeOnly = T)}: Merging data uploads..."))
+    }
+    
+    # merge
+    coded <- merge_datasets(data_upload, cohort)
+    
+    if (debug) {
+      print(glue("{now(timeOnly = T)}: Uncoding data uploads..."))
+    }
+    
+    # uncode
+    uncoded <- uncode_data(df_coded = coded, 
+                          dd = dd,
+                          grs = grs)
+    
+    if (debug) {
+      print(glue("{now(timeOnly = T)}: Formatting uncoded data..."))
+    }
+    
+    # format data
+    uncoded_formatted <- format_rca(uncoded, dd = dd)
+    
+    # separate IRR from non-IRR cases
+    data_pri <- remove_irr(uncoded_formatted)
+    data_irr <- get_irr(uncoded_formatted)
+    
+    if (debug) {
+      print(glue("{now(timeOnly = T)}: Writing uncoded data to file locally..."))
+    }
+    
+    write_output_locally(cohort, data_pri, data_irr)
+    
+    if (save_on_synapse) {
+      
+      if (debug) {
+        print(glue("{now(timeOnly = T)}: Saving uncoded data to Synapse..."))
+      }
+      
+      save_output_synapse(cohort, environment = env)
+    }
+    
+    # clean up for memory
+    rm(data_pri)
+    rm(data_irr)
+    rm(uncoded_formatted)
+    rm(uncoded)
+    rm(coded)
+    rm(data_upload)
   }
-  
-  # clean up for memory
-  rm(data_pri)
-  rm(data_irr)
-  rm(uncoded_formatted)
-  rm(uncoded)
-  rm(coded)
-  rm(data_upload)
+
+  # close out ----------------------------
+
+  toc = as.double(Sys.time())
+  print(glue("Runtime: {round(toc - tic)} s"))
+
 }
 
-# close out ----------------------------
-
-toc = as.double(Sys.time())
-print(glue("Runtime: {round(toc - tic)} s"))
+# only run main when not sourced
+if (sys.nframe() == 0) {
+  main()
+}

--- a/scripts/uploads/tests/test_merge_and_uncode_rca_uploads.R
+++ b/scripts/uploads/tests/test_merge_and_uncode_rca_uploads.R
@@ -1,4 +1,3 @@
-library(mockery)
 library(testthat)
 
 source(testthat::test_path("..", "merge_and_uncode_rca_uploads.R"))

--- a/scripts/uploads/tests/test_merge_and_uncode_rca_uploads.R
+++ b/scripts/uploads/tests/test_merge_and_uncode_rca_uploads.R
@@ -1,0 +1,26 @@
+library(mockery)
+library(testthat)
+
+source(testthat::test_path("..", "merge_and_uncode_rca_uploads.R"))
+
+# Setup code: This will run before any tests
+setup({
+  workdir <- file.path(getwd(), "..")
+  if (!file.exists("config.yaml")) {
+    workdir <- "/usr/local/src/myscripts"
+  }
+  config <<- read_yaml(glue("{workdir}/config.yaml"))
+
+})
+
+
+test_that("get_output_folder_id gets expected id when environment is production", {
+    folder_id <- get_output_folder_id(config, environment = "production")
+    expect_equal(folder_id, "syn23286928")
+})
+
+
+test_that("get_output_folder_id gets expected id when environment is staging", {
+    folder_id <- get_output_folder_id(config, environment = "staging")
+    expect_equal(folder_id, "syn63887337")
+})


### PR DESCRIPTION
**Purpose:** We currently don't have a way to safely test and upload results to non-production environment for `merge_and_decode` step in genie bpc pipeline. This is to add that.

**Changes:**
Aside from the nextflow workflow changes, here are the relevant changes in the `merge_and_uncode_rca_uploads.R` script:

- New helper function [get_output_folder_id](https://github.com/Sage-Bionetworks/genie-bpc-pipeline/pull/161/files#diff-f31d1ddec922f34eb2145359628decffa51aa77c780c287f3d1862b4a49a3b5fR638-R644) to be used to retrieve the output synapse id
- New [`production` flag](https://github.com/Sage-Bionetworks/genie-bpc-pipeline/pull/161/files#diff-f31d1ddec922f34eb2145359628decffa51aa77c780c287f3d1862b4a49a3b5fR705-R706) and logic surrounding it to retrieve the correct entities for staging vs production
- New [comment flag](https://github.com/Sage-Bionetworks/genie-bpc-pipeline/pull/161/files#diff-f31d1ddec922f34eb2145359628decffa51aa77c780c287f3d1862b4a49a3b5fR709-R710) NOTE: this is just a placeholder, we will need to update R and synapser drastically to be able to use this, and that's beyond the scope of this ticket.

**Testing:**
- Added unit testing for helper function `get_output_folder_id`
- Tested on staging project (locally and on tower). Comparison results for a couple of cohorts saved to [JIRA ticket](https://sagebionetworks.jira.com/browse/GEN-1574)
- Not a perfect integration test but ran on `develop` branch docker (except changed the synapse id of the output to staging) and compared it to results on the feature branch docker and no differences found!