### PR TITLE
[GEN-1744] add tier1a replacement param

### DIFF
--- a/main.nf
+++ b/main.nf
@@ -142,7 +142,9 @@ workflow BPC_PIPELINE {
         merge_and_uncode_rca_uploads.out, 
         ch_cohort, 
         ch_comment, 
-        params.production
+        params.production,
+        params.replace_patient_tier1a,
+        params.replace_sample_tier1a
     )
 
     update_date_tracking_table(

--- a/main.nf
+++ b/main.nf
@@ -26,6 +26,8 @@ params.schema_ignore_params = ""
 params.help = false
 params.step = "update_potential_phi_fields_table"
 params.use_grs = false
+params.replace_patient_tier1a = false
+params.replace_sample_tier1a = false
 
 /*
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -110,7 +112,9 @@ workflow BPC_PIPELINE {
         "default", 
         ch_cohort, 
         ch_comment, 
-        params.production
+        params.production,
+        params.replace_patient_tier1a,
+        params.replace_sample_tier1a
     )
    } else if (params.step == "genie_bpc_pipeline"){
     update_potential_phi_fields_table(ch_comment, params.production)

--- a/modules/update_data_table.nf
+++ b/modules/update_data_table.nf
@@ -12,6 +12,8 @@ process update_data_table {
    val cohort
    val comment
    val production
+   val replace_patient_tier1a
+   val replace_sample_tier1a
 
    output:
    stdout
@@ -20,12 +22,12 @@ process update_data_table {
    if (production) {
       """
       cd /root/scripts/
-      python update_data_table.py -p /root/scripts/config.json -c $cohort -m "$comment" primary -pd
+      python update_data_table.py -p /root/scripts/config.json -c $cohort -m "$comment" primary -pd -rp $replace_patient_tier1a -rs $replace_sample_tier1a
       """
    } else {
       """
       cd /root/scripts/
-      python update_data_table.py -p /root/scripts/config.json -c $cohort -m "$comment" primary
+      python update_data_table.py -p /root/scripts/config.json -c $cohort -m "$comment" primary -rp $replace_patient_tier1a -rs $replace_sample_tier1a
       """
    }
 }

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -64,6 +64,24 @@
                         false
                     ]
                 },
+                "replace_patient_tier1a": {
+                    "type": "boolean",
+                    "description": "Whether to overwrite tier1a variables in patient_characteristics table.",
+                    "default": false,
+                    "enum": [
+                        true,
+                        false
+                    ]
+                },
+                "replace_sample_tier1a": {
+                    "type": "boolean",
+                    "description": "Whether to overwrite tier1a variables in cancer_panel_test table.",
+                    "default": false,
+                    "enum": [
+                        true,
+                        false
+                    ]
+                },
                 "references_docker":{
                     "type": "string",
                     "description": "Name of docker to use in processes in scripts/references"

--- a/scripts/table_updates/config.json
+++ b/scripts/table_updates/config.json
@@ -37,9 +37,6 @@
     ],
     "sample_tier1a_column_list_to_be_replaced": [
         "cpt_sample_type",
-        "cpt_seq_date",
-        "cpt_oncotree_code",
-        "cpt_seq_assay_id",
-        "age_at_seq_report"
+        "cpt_seq_date"
     ]
 }

--- a/scripts/table_updates/config.json
+++ b/scripts/table_updates/config.json
@@ -33,8 +33,7 @@
         "naaccr_race_code_primary",
         "naaccr_race_code_secondary",
         "naaccr_race_code_tertiary",
-        "naaccr_sex_code",
-        "birth_year"
+        "naaccr_sex_code"
     ],
     "sample_tier1a_column_list_to_be_replaced": [
         "cpt_sample_type",

--- a/scripts/table_updates/tests/test_utilities.py
+++ b/scripts/table_updates/tests/test_utilities.py
@@ -32,7 +32,8 @@ def config():
         "tier1a_replacement_mapping": {
             "patient_characteristics_tier1a_replacement_mapping_table": "syn22222",
             "cancer_panel_test_tier1a_replacement_mapping_table": "syn33333",
-        }
+        },
+        "main_genie_release_version": "V1",
     }
 
 
@@ -248,6 +249,7 @@ def get__update_tier1a_data_replacement_mapping_table_test_cases():
             "name": "patient_characteristics_mapping",
             "merged_table": pd.DataFrame(
                 {
+                    "cohort": ["A","A", "A"],
                     "genie_patient_id": [1, 2, 3],
                     "naaccr_ethnicity_code": ["A", "B", "C"],
                     "naaccr_race_code_primary": ["X", "Y", "Z"],
@@ -263,8 +265,10 @@ def get__update_tier1a_data_replacement_mapping_table_test_cases():
                 }
             ),
             "form": "patient_characteristics",
+            "cohort": 'A',
             "expected_df": pd.DataFrame(
                 {
+                    "cohort": ["A","A", "A"],
                     "genie_patient_id": [1, 2, 3],
                     "naaccr_ethnicity_code": ["A", "B", "C"],
                     "naaccr_race_code_primary": ["X", "Y", "Z"],
@@ -276,6 +280,7 @@ def get__update_tier1a_data_replacement_mapping_table_test_cases():
                     "SECONDARY_RACE_DETAILED": ["Race P", "Race Q", "Race R"],
                     "TERTIARY_RACE_DETAILED": ["Race M", "Race N", "Race O"],
                     "SEX_DETAILED": ["Male", "Female", "Male"],
+                    "Main_Genie_Release_Version": ["V1", "V1", "V1"],
                 }
             ),
         },
@@ -283,6 +288,7 @@ def get__update_tier1a_data_replacement_mapping_table_test_cases():
             "name": "cancer_panel_test_mapping",
             "merged_table": pd.DataFrame(
                 {
+                    "cohort": ["A","A", "A"],
                     "cpt_genie_sample_id": [1, 2, 3],
                     "cpt_sample_type": ["A", "B", "C"],
                     "cpt_seq_date": ["X", "Y", "Z"],
@@ -292,13 +298,43 @@ def get__update_tier1a_data_replacement_mapping_table_test_cases():
                 }
             ),
             "form": "cancer_panel_test",
+            "cohort": 'A',
             "expected_df": pd.DataFrame(
                 {
+                    "cohort": ["A","A", "A"],
                     "cpt_genie_sample_id": [1, 2, 3],
                     "cpt_sample_type": ["A", "B", "C"],
                     "cpt_seq_date": ["X", "Y", "Z"],
                     "SAMPLE_TYPE_DETAILED": ["P", "Q", "R"],
                     "SEQ_YEAR": ["M", "N", "O"],
+                    "Main_Genie_Release_Version": ["V1", "V1", "V1"],
+                }
+            ),
+        },
+        {
+            "name": "cancer_panel_test_mapping_all_cohorts",
+            "merged_table": pd.DataFrame(
+                {
+                    "cohort": ["A","A", "A"],
+                    "cpt_genie_sample_id": [1, 2, 3],
+                    "cpt_sample_type": ["A", "B", "C"],
+                    "cpt_seq_date": ["X", "Y", "Z"],
+                    "SAMPLE_TYPE_DETAILED": ["P", "Q", "R"],
+                    "SEQ_YEAR": ["M", "N", "O"],
+                    "other_cols": [1, 2, 3],
+                }
+            ),
+            "form": "cancer_panel_test",
+            "cohort": "",
+            "expected_df": pd.DataFrame(
+                {
+                    "cohort": ["A","A", "A"],
+                    "cpt_genie_sample_id": [1, 2, 3],
+                    "cpt_sample_type": ["A", "B", "C"],
+                    "cpt_seq_date": ["X", "Y", "Z"],
+                    "SAMPLE_TYPE_DETAILED": ["P", "Q", "R"],
+                    "SEQ_YEAR": ["M", "N", "O"],
+                    "Main_Genie_Release_Version": ["V1", "V1", "V1"],
                 }
             ),
         },
@@ -313,17 +349,23 @@ def get__update_tier1a_data_replacement_mapping_table_test_cases():
 def test_update_tier1a_data_replacement_mapping_table(syn, table_schema, test_cases, config):
     with patch.object(syn, "get", return_value=table_schema) as patch_get, patch.object(
         syn, "tableQuery"
-    ) as patch_table_query, patch.object(syn, "store") as patch_store, patch.object(syn, "delete") as patch_delete:
+    ) as patch_table_query, patch.object(syn, "store") as patch_store, patch.object(syn, "delete") as patch_delete, patch('utilities.update_version') as update_version:
         patch_table_query.return_value = MagicMock(etag="test_etag")
+        logger = MagicMock(spec=logging.Logger)
+
+        comment = "test comment"
         # Call the function
         update_tier1a_data_replacement_mapping_table(
-            syn, test_cases["merged_table"], test_cases["form"], config
+            syn, test_cases["merged_table"], test_cases["form"], config, comment=comment, logger=logger, cohort=test_cases["cohort"]
         )
 
         # Validate
         patch_get.assert_called_with(
             config["tier1a_replacement_mapping"][f"{test_cases['form']}_tier1a_replacement_mapping_table"])
-        patch_table_query.assert_called_with(f"SELECT * FROM {table_schema.id}")
+        if test_cases["cohort"]:
+            patch_table_query.assert_called_with(f"SELECT * FROM {table_schema.id} where cohort = '{test_cases['cohort']}'")
+        else:
+            patch_table_query.assert_called_with(f"SELECT * FROM {table_schema.id}")
         patch_delete.assert_called_once()
         args, kwargs = patch_store.call_args
         stored_table = args[0]
@@ -331,3 +373,6 @@ def test_update_tier1a_data_replacement_mapping_table(syn, table_schema, test_ca
         pd.testing.assert_frame_equal(
             stored_table.asDataFrame(), test_cases["expected_df"]
         )
+        logger.info.assert_called_with("Updating version for tier1a data replacement mapping table")
+        update_version.assert_called_with(syn, table_schema.id, f"{comment}_mainGENIE_{config['main_genie_release_version']}")
+

--- a/scripts/table_updates/tests/test_utilities.py
+++ b/scripts/table_updates/tests/test_utilities.py
@@ -265,6 +265,8 @@ def get__update_tier1a_data_replacement_mapping_table_test_cases():
                 }
             ),
             "form": "patient_characteristics",
+            "bpc_column_list": ["naaccr_ethnicity_code", "naaccr_race_code_primary", "naaccr_race_code_secondary", "naaccr_race_code_tertiary", "naaccr_sex_code"],
+            "main_genie_column_list": ["ETHNICITY_DETAILED", "PRIMARY_RACE_DETAILED", "SECONDARY_RACE_DETAILED", "TERTIARY_RACE_DETAILED", "SEX_DETAILED"],
             "cohort": 'A',
             "expected_df": pd.DataFrame(
                 {
@@ -298,6 +300,8 @@ def get__update_tier1a_data_replacement_mapping_table_test_cases():
                 }
             ),
             "form": "cancer_panel_test",
+            "bpc_column_list": ["cpt_sample_type", "cpt_seq_date"],
+            "main_genie_column_list": ["SAMPLE_TYPE_DETAILED", "SEQ_YEAR"],
             "cohort": 'A',
             "expected_df": pd.DataFrame(
                 {
@@ -325,6 +329,8 @@ def get__update_tier1a_data_replacement_mapping_table_test_cases():
                 }
             ),
             "form": "cancer_panel_test",
+            "bpc_column_list": ["cpt_sample_type", "cpt_seq_date"],
+            "main_genie_column_list": ["SAMPLE_TYPE_DETAILED", "SEQ_YEAR"],
             "cohort": "",
             "expected_df": pd.DataFrame(
                 {
@@ -356,7 +362,7 @@ def test_update_tier1a_data_replacement_mapping_table(syn, table_schema, test_ca
         comment = "test comment"
         # Call the function
         update_tier1a_data_replacement_mapping_table(
-            syn, test_cases["merged_table"], test_cases["form"], config, comment=comment, logger=logger, cohort=test_cases["cohort"]
+            syn, test_cases["merged_table"], test_cases["form"], config, comment=comment, logger=logger, bpc_column_list = test_cases["bpc_column_list"], main_genie_column_list=test_cases["main_genie_column_list"],cohort=test_cases["cohort"]
         )
 
         # Validate

--- a/scripts/table_updates/update_data_table.py
+++ b/scripts/table_updates/update_data_table.py
@@ -697,7 +697,55 @@ def custom_fix_for_tier1a_variable(
             bpc_column_list=config["sample_tier1a_column_list_to_be_replaced"],
             logger=logger,
         )
-        logger.info("Overwrite tier1a sample variables completed!")
+        logger.info("Overwrite tier1a sample variables completed!")            
+
+def custom_fix_for_cpt_seq_data(
+        syn: synapseclient.Synapse,
+        master_table: pandas.DataFrame,
+        logger: logging.Logger,
+        config: dict,
+        cohort: str = "",
+        comment: str = "",
+    ) -> None:
+    # unlist form column in master table
+    master_table["form"] = master_table["form"].apply(lambda x: ", ".join(x))
+    # load GENIE BPC elements mapping table
+    column_mapping_table = utilities.download_synapse_table(syn, "syn20945902")
+
+    # load main genie sample file
+    genie_sample_dat = get_main_genie_clinical_file(
+        syn,
+        release=config["main_genie_release_version"],
+        release_files_table_synid=config["main_genie_data_release_files"],
+        form="cancer_panel_test",
+        column_mapping_table=column_mapping_table,
+        logger=logger,
+        )
+    # modify for sample table
+    cpt_table_id, cpt_seq_dat = update_tier1a(
+        syn,
+        "cancer_panel_test",
+        master_table,
+        genie_sample_dat,
+        column_mapping_table,
+        bpc_column_list=["cpt_seq_date"],
+        config=config,
+        logger=logger,
+        cohort=cohort,
+        comment=comment
+    )
+    # reformat cpt_seq_date column
+    cpt_seq_dat["cpt_seq_date"] = cpt_seq_dat["cpt_seq_date"].map(utilities.float_to_int)
+    overwrite_tier1a(
+        syn,
+        "cancer_panel_test",
+        cpt_table_id,
+        cpt_seq_dat,
+        bpc_column_list=["cpt_seq_date"],
+        logger=logger,
+    )
+
+    logger.info("Overwrite cpt_seq_date completed!")            
 
 def main():
     # add arguments
@@ -791,6 +839,9 @@ def main():
     if not dry_run:
         if replace_patient_tier1a or replace_sample_tier1a:
             custom_fix_for_tier1a_variable(syn, master_table, logger, config, cohort, replace_patient_tier1a, replace_sample_tier1a, comment)
+        if not replace_sample_tier1a:
+            # replace cpt_seq_date separately if not replace other tier1a variables in cancer panel test table
+            custom_fix_for_cpt_seq_data(syn, master_table, logger, config, cohort, comment)
         if table_type == "primary":
             table_id, condition = list(TABLE_INFO["redacted"])
             redacted_table_info = utilities.download_synapse_table(

--- a/scripts/table_updates/update_data_table.py
+++ b/scripts/table_updates/update_data_table.py
@@ -564,7 +564,7 @@ def update_tier1a(
             left_on="cpt_genie_sample_id",
             right_on="SAMPLE_ID",
         )
-    utilities.update_tier1a_data_replacement_mapping_table(syn, merged_table = cpt_seq_dat, form = form, config = config, comment = comment, logger = logger,cohort = cohort)
+    utilities.update_tier1a_data_replacement_mapping_table(syn, merged_table = cpt_seq_dat, form = form, config = config, comment = comment, logger = logger, bpc_column_list = bpc_column_list, main_genie_column_list = main_genie_column_list, cohort = cohort)
     # reformat the columns
     cpt_seq_dat.index = cpt_seq_dat["index"]
     cpt_seq_dat.index.name = None
@@ -706,9 +706,12 @@ def custom_fix_for_cpt_seq_data(
         config: dict,
         cohort: str = "",
         comment: str = "",
+        replace_patient_tier1a: bool = False, 
+        replace_sample_tier1a: bool = False, 
     ) -> None:
-    # unlist form column in master table
-    master_table["form"] = master_table["form"].apply(lambda x: ", ".join(x))
+    # unlist form column in master table only when not replacing tier1a variables
+    if not (replace_patient_tier1a or replace_sample_tier1a):
+        master_table["form"] = master_table["form"].apply(lambda x: ", ".join(x))
     # load GENIE BPC elements mapping table
     column_mapping_table = utilities.download_synapse_table(syn, "syn20945902")
 
@@ -782,14 +785,16 @@ def main():
     parser.add_argument(
         "-rp",
         "--replace_patient_tier1a",
-        action="store_true",
-        help="Replace tier1a variables in patient_characteristics table",
+        type = lambda x: x.lower()== 'true',
+        default=False,
+        help="Whether to replace tier1a variables in patient_characteristics table",
     )
     parser.add_argument(
         "-rs",
         "--replace_sample_tier1a",
-        action="store_true",
-        help="Replace tier1a variables in cancer_panel_test table",
+        type = lambda x: x.lower()== 'true',
+        default=False,
+        help="Whether to replace tier1a variables in cancer_panel_test table",
     )
     parser.add_argument("-m", "--message", default="", help="Version comment")
     parser.add_argument("-d", "--dry_run", action="store_true", help="dry run flag")
@@ -841,7 +846,7 @@ def main():
             custom_fix_for_tier1a_variable(syn, master_table, logger, config, cohort, replace_patient_tier1a, replace_sample_tier1a, comment)
         if not replace_sample_tier1a:
             # replace cpt_seq_date separately if not replace other tier1a variables in cancer panel test table
-            custom_fix_for_cpt_seq_data(syn, master_table, logger, config, cohort, comment)
+            custom_fix_for_cpt_seq_data(syn, master_table, logger, config, cohort, comment, replace_patient_tier1a, replace_sample_tier1a)
         if table_type == "primary":
             table_id, condition = list(TABLE_INFO["redacted"])
             redacted_table_info = utilities.download_synapse_table(

--- a/scripts/table_updates/update_data_table.py
+++ b/scripts/table_updates/update_data_table.py
@@ -484,6 +484,7 @@ def update_tier1a(
     config: dict,
     logger: logging.Logger = None,
     cohort: str = "",
+    comment: str = "",
 ) -> Tuple[str, pandas.DataFrame]:
     """Replace tier1a variables in patient_characteristics or cancer_panel_test table with Main GENIE release files
 
@@ -563,7 +564,7 @@ def update_tier1a(
             left_on="cpt_genie_sample_id",
             right_on="SAMPLE_ID",
         )
-    utilities.update_tier1a_data_replacement_mapping_table(syn, cpt_seq_dat, form, config)
+    utilities.update_tier1a_data_replacement_mapping_table(syn, merged_table = cpt_seq_dat, form = form, config = config, comment = comment, logger = logger,cohort = cohort)
     # reformat the columns
     cpt_seq_dat.index = cpt_seq_dat["index"]
     cpt_seq_dat.index.name = None
@@ -609,6 +610,9 @@ def custom_fix_for_tier1a_variable(
     logger: logging.Logger,
     config: dict,
     cohort: str = "",
+    replace_patient_tier1a: bool = False, 
+    replace_sample_tier1a: bool = False, 
+    comment: str = "",
 ) -> None:
     """
     This overwrites tier1a
@@ -619,70 +623,81 @@ def custom_fix_for_tier1a_variable(
         logger (logging.Logger): logger object
         config (dict): config read in
         cohort (str): cohort name
+        replace_patient_tier1a (bool): whether to replace patient tier1a variables
+        replace_sample_tier1a (bool): whether to replace sample tier1a variables
+        comment (str): version comment
     """
-    logger.info("Overwrite tier1a variables in progress...")
-    # load GENIE BPC elements mapping table
-    column_mapping_table = utilities.download_synapse_table(syn, "syn20945902")
-    genie_patient_dat = get_main_genie_clinical_file(
-        syn,
-        release=config["main_genie_release_version"],
-        release_files_table_synid=config["main_genie_data_release_files"],
-        form="patient_characteristics",
-        column_mapping_table=column_mapping_table,
-        logger=logger,
-    )
-    genie_sample_dat = get_main_genie_clinical_file(
-        syn,
-        release=config["main_genie_release_version"],
-        release_files_table_synid=config["main_genie_data_release_files"],
-        form="cancer_panel_test",
-        column_mapping_table=column_mapping_table,
-        logger=logger,
-    )
     # unlist form column in master table
     master_table["form"] = master_table["form"].apply(lambda x: ", ".join(x))
-    # modify for patient table
-    cpt_table_id, cpt_seq_dat = update_tier1a(
-        syn,
-        "patient_characteristics",
-        master_table,
-        genie_patient_dat,
-        column_mapping_table,
-        bpc_column_list= config['patient_tier1a_column_list_to_be_replaced'],
-        config=config,
-        logger=logger,
-        cohort=cohort,
-    )
-    overwrite_tier1a(
-        syn,
-        "patient_characteristics",
-        cpt_table_id,
-        cpt_seq_dat,
-        bpc_column_list=config['patient_tier1a_column_list_to_be_replaced'],
-        logger=logger,
-    )
-    # modify for sample table
-    cpt_table_id, cpt_seq_dat = update_tier1a(
-        syn,
-        "cancer_panel_test",
-        master_table,
-        genie_sample_dat,
-        column_mapping_table,
-        bpc_column_list=config["sample_tier1a_column_list_to_be_replaced"],
-        config=config,
-        logger=logger,
-        cohort=cohort,
-    )
-    overwrite_tier1a(
-        syn,
-        "cancer_panel_test",
-        cpt_table_id,
-        cpt_seq_dat,
-        bpc_column_list=config["sample_tier1a_column_list_to_be_replaced"],
-        logger=logger,
-    )
-    logger.info("Completed")
+    # load GENIE BPC elements mapping table
+    column_mapping_table = utilities.download_synapse_table(syn, "syn20945902")
 
+    if replace_patient_tier1a:
+        logger.info("Replace patient tier1a variables in progress...")
+        # load main genie patient file
+        genie_patient_dat = get_main_genie_clinical_file(
+            syn,
+            release=config["main_genie_release_version"],
+            release_files_table_synid=config["main_genie_data_release_files"],
+            form="patient_characteristics",
+            column_mapping_table=column_mapping_table,
+            logger=logger,
+        )
+        # modify for patient table
+        cpt_table_id, cpt_seq_dat = update_tier1a(
+            syn,
+            "patient_characteristics",
+            master_table,
+            genie_patient_dat,
+            column_mapping_table,
+            bpc_column_list= config['patient_tier1a_column_list_to_be_replaced'],
+            config=config,
+            logger=logger,
+            cohort=cohort,
+            comment=comment
+        )
+        overwrite_tier1a(
+            syn,
+            "patient_characteristics",
+            cpt_table_id,
+            cpt_seq_dat,
+            bpc_column_list=config['patient_tier1a_column_list_to_be_replaced'],
+            logger=logger,
+        )
+        logger.info("Overwrite tier1a patient variables completed!")
+
+    if replace_sample_tier1a:
+        # load main genie sample file
+        genie_sample_dat = get_main_genie_clinical_file(
+            syn,
+            release=config["main_genie_release_version"],
+            release_files_table_synid=config["main_genie_data_release_files"],
+            form="cancer_panel_test",
+            column_mapping_table=column_mapping_table,
+            logger=logger,
+    )
+        # modify for sample table
+        cpt_table_id, cpt_seq_dat = update_tier1a(
+            syn,
+            "cancer_panel_test",
+            master_table,
+            genie_sample_dat,
+            column_mapping_table,
+            bpc_column_list=config["sample_tier1a_column_list_to_be_replaced"],
+            config=config,
+            logger=logger,
+            cohort=cohort,
+            comment=comment
+        )
+        overwrite_tier1a(
+            syn,
+            "cancer_panel_test",
+            cpt_table_id,
+            cpt_seq_dat,
+            bpc_column_list=config["sample_tier1a_column_list_to_be_replaced"],
+            logger=logger,
+        )
+        logger.info("Overwrite tier1a sample variables completed!")
 
 def main():
     # add arguments
@@ -716,6 +731,18 @@ def main():
         action="store_true",
         help="Save output to production folder",
     )
+    parser.add_argument(
+        "-rp",
+        "--replace_patient_tier1a",
+        action="store_true",
+        help="Replace tier1a variables in patient_characteristics table",
+    )
+    parser.add_argument(
+        "-rs",
+        "--replace_sample_tier1a",
+        action="store_true",
+        help="Replace tier1a variables in cancer_panel_test table",
+    )
     parser.add_argument("-m", "--message", default="", help="Version comment")
     parser.add_argument("-d", "--dry_run", action="store_true", help="dry run flag")
 
@@ -725,6 +752,8 @@ def main():
     project_config = args.project_config
     cohort = args.cohort
     production = args.production
+    replace_patient_tier1a = args.replace_patient_tier1a
+    replace_sample_tier1a = args.replace_sample_tier1a
     comment = args.message
     dry_run = args.dry_run
 
@@ -760,14 +789,8 @@ def main():
     # update data tables
     store_data(syn, master_table, label_data, table_type, cohort, logger, dry_run)
     if not dry_run:
-        custom_fix_for_tier1a_variable(syn, master_table, logger, config, cohort)
-        logger.info("Updating version for tier1a replacement mapping tables")
-        for table_id in config["tier1a_replacement_mapping"].values():
-            utilities.update_version(
-                syn,
-                table_id,
-                f"{comment}_mainGENIE_{config['main_genie_release_version']}",
-            )
+        if replace_patient_tier1a or replace_sample_tier1a:
+            custom_fix_for_tier1a_variable(syn, master_table, logger, config, cohort, replace_patient_tier1a, replace_sample_tier1a, comment)
         if table_type == "primary":
             table_id, condition = list(TABLE_INFO["redacted"])
             redacted_table_info = utilities.download_synapse_table(

--- a/scripts/table_updates/utilities.py
+++ b/scripts/table_updates/utilities.py
@@ -213,7 +213,7 @@ def remove_backslash(df: pandas.DataFrame, cols: List[str]) -> pandas.DataFrame:
 
 
 def update_tier1a_data_replacement_mapping_table(
-    syn: synapseclient.Synapse, merged_table: pandas.DataFrame, form: str, config: dict, comment: str, logger: logging.Logger, cohort: str = ""):
+    syn: synapseclient.Synapse, merged_table: pandas.DataFrame, form: str, config: dict, comment: str, logger: logging.Logger, bpc_column_list: List[str], main_genie_column_list: List[str],cohort: str = ""):
     """Update tier1a data replacement mapping table
 
     Args:
@@ -234,19 +234,11 @@ def update_tier1a_data_replacement_mapping_table(
         subset_table = merged_table[
             [   
                 "cohort",
-                "genie_patient_id",
-                "naaccr_ethnicity_code",
-                "naaccr_race_code_primary",
-                "naaccr_race_code_secondary",
-                "naaccr_race_code_tertiary",
-                "naaccr_sex_code",
-                "ETHNICITY_DETAILED",
-                "PRIMARY_RACE_DETAILED",
-                "SECONDARY_RACE_DETAILED",
-                "TERTIARY_RACE_DETAILED",
-                "SEX_DETAILED",
+                "genie_patient_id"
             ]
-        ]
+                + bpc_column_list
+                + main_genie_column_list
+            ]
     if form == "cancer_panel_test":
         table_schema = syn.get(
             config["tier1a_replacement_mapping"][
@@ -256,13 +248,11 @@ def update_tier1a_data_replacement_mapping_table(
         subset_table = merged_table[
             [
                 "cohort",
-                "cpt_genie_sample_id",
-                "cpt_sample_type",
-                "cpt_seq_date",
-                "SAMPLE_TYPE_DETAILED",
-                "SEQ_YEAR",
+                "cpt_genie_sample_id"]
+                + bpc_column_list
+                + main_genie_column_list
             ]
-        ]
+
     subset_table["Main_Genie_Release_Version"] = config["main_genie_release_version"]
     # save the table to sage internal project
     subset_table.reset_index(drop=True, inplace=True)

--- a/scripts/table_updates/utilities.py
+++ b/scripts/table_updates/utilities.py
@@ -213,13 +213,17 @@ def remove_backslash(df: pandas.DataFrame, cols: List[str]) -> pandas.DataFrame:
 
 
 def update_tier1a_data_replacement_mapping_table(
-    syn: synapseclient.Synapse, merged_table: pandas.DataFrame, form: str, config: dict
-):
+    syn: synapseclient.Synapse, merged_table: pandas.DataFrame, form: str, config: dict, comment: str, logger: logging.Logger, cohort: str = ""):
     """Update tier1a data replacement mapping table
 
     Args:
+        syn (synapseclient.Synapse): Synapse object
         merged_table (pandas.DataFrame): The merged table
         form (str): The form name
+        config (dict): config read in
+        comment (str): The version comment
+        logger (logging.Logger): The logger object
+        cohort (str): The cohort name
     """
     if form == "patient_characteristics":
         table_schema = syn.get(
@@ -228,7 +232,8 @@ def update_tier1a_data_replacement_mapping_table(
             ]
         )
         subset_table = merged_table[
-            [
+            [   
+                "cohort",
                 "genie_patient_id",
                 "naaccr_ethnicity_code",
                 "naaccr_race_code_primary",
@@ -250,6 +255,7 @@ def update_tier1a_data_replacement_mapping_table(
         )
         subset_table = merged_table[
             [
+                "cohort",
                 "cpt_genie_sample_id",
                 "cpt_sample_type",
                 "cpt_seq_date",
@@ -257,8 +263,15 @@ def update_tier1a_data_replacement_mapping_table(
                 "SEQ_YEAR",
             ]
         ]
+    subset_table["Main_Genie_Release_Version"] = config["main_genie_release_version"]
     # save the table to sage internal project
     subset_table.reset_index(drop=True, inplace=True)
-    table_query = syn.tableQuery(f"SELECT * FROM {table_schema.id}")
-    table = syn.delete(table_query)
+    if cohort:
+        table_query = syn.tableQuery(f"SELECT * FROM {table_schema.id} where cohort = '{cohort}'")
+    else:
+        table_query = syn.tableQuery(f"SELECT * FROM {table_schema.id}")
+    table = syn.delete(table_query)  # wipe the cohort data
     table = syn.store(Table(table_schema, subset_table))
+    # update the version
+    logger.info("Updating version for tier1a data replacement mapping table")
+    update_version(syn, table_schema.id, f"{comment}_mainGENIE_{config['main_genie_release_version']}")


### PR DESCRIPTION
Problem:

1. Currently, there is no option to disable Tier1a replacement.
2. The mapping table updates are not cohort-specific.

Solution:

1. Introduce parameters to toggle Tier1a patient and/or sample variable replacement on or off.
2. Modify the mapping table to incorporate the Tier1a replacement parameter and enable cohort-specific table queries.