### PR TITLE
[GEN-1766] Fix merge_and_uncode issue

### DIFF
--- a/modules/merge_and_uncode_rca_uploads.nf
+++ b/modules/merge_and_uncode_rca_uploads.nf
@@ -22,7 +22,7 @@ process merge_and_uncode_rca_uploads {
       """
       cd /usr/local/src/myscripts/
       Rscript merge_and_uncode_rca_uploads.R \
-         -c $cohort 
+         -c $cohort \
          -v \
          --production \
          --save_synapse \


### PR DESCRIPTION
**Purpose:** There was a missing slash in the `merge_and_uncode` command for `production`