### PR TITLE
[GEN-1702] Update config.json

### DIFF
--- a/scripts/table_updates/config.json
+++ b/scripts/table_updates/config.json
@@ -25,7 +25,7 @@
         "patient_characteristics_tier1a_replacement_mapping_table": "syn64331052",
         "cancer_panel_test_tier1a_replacement_mapping_table": "syn64331055"
     },
-    "main_genie_release_version": "17.6-consortium",
+    "main_genie_release_version": "9.1-consortium",
     "main_genie_data_release_files": "syn16804261",
     "main_genie_sample_mapping_table": "syn7434273",
     "patient_tier1a_column_list_to_be_replaced": [
@@ -36,7 +36,6 @@
         "naaccr_sex_code"
     ],
     "sample_tier1a_column_list_to_be_replaced": [
-        "cpt_sample_type",
-        "cpt_seq_date"
+        "cpt_sample_type"
     ]
 }


### PR DESCRIPTION
Updating config to test BrCa 1.0-public updates. 

BrCa data lock is "9.1-consortium" per this slide deck: https://aacr.ent.box.com/s/ma8k8yw8j0s3bwvo7d2zq3t4um2juy88

We are not replacing `cpt_seq_date`