### PR TITLE
[GEN-1774] Add ability to replace with the non _DETAILED tier1a columns

### DIFF
--- a/scripts/table_updates/README.md
+++ b/scripts/table_updates/README.md
@@ -47,6 +47,10 @@ Usage
 
 ##### 3. staging (Save output to staging projects)
     python update_data_table.py -c [cohort_name] -m [version_comment] primary
-    
+
+##### 4. replace tier1a variables in patient_characteristics and cancer_panel_test tables
+
+    python update_data_table.py -c [cohort_name] -m [version_comment] primary -rs true -rp true
+
 #### IRR Case Tables (Deprecated)
     python update_data_table.py -m [version_comment] irr

--- a/scripts/table_updates/README.md
+++ b/scripts/table_updates/README.md
@@ -49,6 +49,7 @@ Usage
     python update_data_table.py -c [cohort_name] -m [version_comment] primary
 
 ##### 4. replace tier1a variables in patient_characteristics and cancer_panel_test tables
+Once the column mappings are confirmed for both the cohort and the main GENIE release version in [GENIE BPC Elements Mapping](https://www.synapse.org/Synapse:syn20945902/tables/), proceed to run
 
     python update_data_table.py -c [cohort_name] -m [version_comment] primary -rs true -rp true
 

--- a/scripts/table_updates/config.json
+++ b/scripts/table_updates/config.json
@@ -25,6 +25,7 @@
         "patient_characteristics_tier1a_replacement_mapping_table": "syn65880480",
         "cancer_panel_test_tier1a_replacement_mapping_table": "syn65880475"
     },
+    "genie_bpc_elements_mapping": "syn20945902",
     "main_genie_release_version": "9.1-consortium",
     "main_genie_data_release_files": "syn16804261",
     "main_genie_sample_mapping_table": "syn7434273",
@@ -36,6 +37,7 @@
         "naaccr_sex_code"
     ],
     "sample_tier1a_column_list_to_be_replaced": [
-        "cpt_sample_type"
+        "cpt_sample_type",
+        "cpt_seq_date"
     ]
 }

--- a/scripts/table_updates/tests/test_update_data_table.py
+++ b/scripts/table_updates/tests/test_update_data_table.py
@@ -14,6 +14,7 @@ from update_data_table import *
 def syn():
     return create_autospec(synapseclient.Synapse)
 
+
 @pytest.fixture
 def master_table():
     return pd.DataFrame(
@@ -21,7 +22,8 @@ def master_table():
             "form": ["patient_characteristics", "cancer_panel_test"],
             "id": ["syn123", "syn456"],
         }
-        )
+    )
+
 
 @pytest.fixture
 def mock_synapse(syn):
@@ -35,22 +37,94 @@ def mock_synapse(syn):
     syn.get.return_value = MagicMock(path="path/to/clinical_file.csv")
     return syn, release_files_table_synid
 
+
 @pytest.fixture
 def mock_release_version():
     return "v1.0"
 
+
 @pytest.fixture
 def column_mapping_table():
     return pd.DataFrame(
-        {"genie_element": ["ETHNICITY_DETAILED", "PRIMARY_RACE_DETAILED", "SEQ_YEAR", "SAMPLE_TYPE_DETAILED"], 
-        "prissmm_element": ["naaccr_ethnicity_code", "naaccr_race_code_primary", "cpt_seq_date", "cpt_sample_type"],
-        "prissmm_form": ["patient_characteristics", "patient_characteristics", "cancer_panel_test", "cancer_panel_test"]}
-        )
+        {
+            "genie_element": [
+                "ETHNICITY_DETAILED",
+                "PRIMARY_RACE_DETAILED",
+                "SEQ_YEAR",
+                "SAMPLE_TYPE_DETAILED",
+                "ETHNICITY",
+                "PRIMARY_RACE",
+                "SEQ_YEAR",
+                "SAMPLE_TYPE",
+                "ETHNICITY_DETAILED",
+                "PRIMARY_RACE_DETAILED",
+                "SEQ_YEAR",
+                "SAMPLE_TYPE_DETAILED",
+            ],
+            "prissmm_element": [
+                "naaccr_ethnicity_code",
+                "naaccr_race_code_primary",
+                "cpt_seq_date",
+                "cpt_sample_type",
+                "naaccr_ethnicity_code",
+                "naaccr_race_code_primary",
+                "cpt_seq_date",
+                "cpt_sample_type",
+                "naaccr_ethnicity_code",
+                "naaccr_race_code_primary",
+                "cpt_seq_date",
+                "cpt_sample_type",
+            ],
+            "prissmm_form": [
+                "patient_characteristics",
+                "patient_characteristics",
+                "cancer_panel_test",
+                "cancer_panel_test",
+                "patient_characteristics",
+                "patient_characteristics",
+                "cancer_panel_test",
+                "cancer_panel_test",
+                "patient_characteristics",
+                "patient_characteristics",
+                "cancer_panel_test",
+                "cancer_panel_test",
+            ],
+            "main_genie_release": [
+                "v1.0",
+                "v1.0",
+                "v1.0",
+                "v1.0",
+                "v1.0",
+                "v1.0",
+                "v1.0",
+                "v1.0",
+                "v1.0",
+                "v1.0",
+                "v1.0",
+                "v1.0",
+            ],
+            "cohort": [
+                "NSCLC",
+                "NSCLC",
+                "NSCLC",
+                "NSCLC",
+                "CRC",
+                "CRC",
+                "CRC",
+                "CRC",
+                "",
+                "",
+                "",
+                "",
+            ],
+        }
+    )
+
 
 @pytest.fixture
 def config():
     yield {
-        "primary":{
+        "primary": {
             "NSCLC": "syn23285494",
             "CRC": "syn23285418",
             "BrCa": "syn23286608",
@@ -59,22 +133,22 @@ def config():
             "BLADDER": "syn26721150",
             "NSCLC2": "syn51318735",
             "CRC2": "syn52943208",
-            "RENAL": "syn59474241"
+            "RENAL": "syn59474241",
         },
-        "irr":{
+        "irr": {
             "BrCa": "syn24241519",
             "PANC": "syn25610271",
             "Prostate": "syn26275497",
             "BLADDER": "syn26721151",
             "NSCLC2": "syn51318736",
             "CRC2": "syn52943210",
-            "RENAL": "syn59474249"
+            "RENAL": "syn59474249",
         },
-        "tier1a_replacement_mapping":{
+        "tier1a_replacement_mapping": {
             "patient_characteristics_tier1a_replacement_mapping_table": "syn22222",
-            "cancer_panel_test_tier1a_replacement_mapping_table": "syn33333"
+            "cancer_panel_test_tier1a_replacement_mapping_table": "syn33333",
         },
-        "main_genie_release_version": "16.6-consortium",
+        "main_genie_release_version": "v1.0",
         "main_genie_data_release_files": "syn16804261",
         "main_genie_sample_mapping_table": "syn7434273",
         "patient_tier1a_column_list_to_be_replaced": [
@@ -82,12 +156,11 @@ def config():
             "naaccr_race_code_primary",
             "naaccr_race_code_secondary",
             "naaccr_race_code_tertiary",
-            "naaccr_sex_code"
+            "naaccr_sex_code",
         ],
-    "sample_tier1a_column_list_to_be_replaced": [
-        "cpt_sample_type", "cpt_seq_date"
-        ]
+        "sample_tier1a_column_list_to_be_replaced": ["cpt_sample_type", "cpt_seq_date"],
     }
+
 
 @pytest.fixture
 def release_files_df():
@@ -97,93 +170,211 @@ def release_files_df():
             "fileSynId": ["syn23456", "syn34567"],
             "name": ["data_clinical_sample.txt", "data_clinical_patient.txt"],
         }
-        )
+    )
+
 
 @pytest.mark.parametrize(
-    "clinical_df_mock,form,clinical_link_synid",
+    "clinical_df_mock,cohort,form,clinical_link_synid",
     [
-        (pd.DataFrame({"PATIENT_ID": [1, 2, 3], "ETHNICITY_DETAILED": [1, 2, 3],"PRIMARY_RACE_DETAILED":[1, 2, 3] ,"OTHER_ID": [6, 7, 8]}), "patient_characteristics", "syn34567"),
-        (pd.DataFrame({"SAMPLE_ID": [1, 2, 3], "SEQ_YEAR": [2014, 2014, 2013], "SAMPLE_TYPE_DETAILED": [1, 2, 3],"OTHER_ID": [6, 7, 8]}), "cancer_panel_test", "syn23456"),
+        (
+            pd.DataFrame(
+                {
+                    "PATIENT_ID": [1, 2, 3],
+                    "ETHNICITY_DETAILED": [1, 2, 3],
+                    "PRIMARY_RACE_DETAILED": [1, 2, 3],
+                    "OTHER_ID": [6, 7, 8],
+                }
+            ),
+            "NSCLC",
+            "patient_characteristics",
+            "syn34567",
+        ),
+        (
+            pd.DataFrame(
+                {
+                    "SAMPLE_ID": [1, 2, 3],
+                    "SEQ_YEAR": [2014, 2014, 2013],
+                    "SAMPLE_TYPE_DETAILED": [1, 2, 3],
+                    "OTHER_ID": [6, 7, 8],
+                }
+            ),
+            "NSCLC",
+            "cancer_panel_test",
+            "syn23456",
+        ),
     ],
-    ids=["get_patient_file", "get_sample_file"]
+    ids=["get_patient_file", "get_sample_file"],
 )
 def test_get_main_genie_clinical_file_success(
-    mock_synapse, mock_release_version, release_files_df, column_mapping_table, clinical_df_mock, form, clinical_link_synid
+    mock_synapse,
+    mock_release_version,
+    cohort,
+    release_files_df,
+    column_mapping_table,
+    clinical_df_mock,
+    form,
+    clinical_link_synid,
 ):
-    with patch.object(utilities, "download_synapse_table", return_value = release_files_df) as mock_download_synapse_table, patch.object(pandas,"read_csv", return_value=clinical_df_mock) as mock_read_csv:
- 
+    with patch.object(
+        utilities, "download_synapse_table", return_value=release_files_df
+    ) as mock_download_synapse_table, patch.object(
+        pandas, "read_csv", return_value=clinical_df_mock
+    ) as mock_read_csv:
         syn, mock_release_files_table_synid = mock_synapse
         mock_logger = MagicMock(spec=logging.Logger)
-  
+
         # Call the function
         results = get_main_genie_clinical_file(
-               syn, mock_release_version, mock_release_files_table_synid, form = form, column_mapping_table =column_mapping_table, logger = mock_logger
-            )
+            syn,
+            mock_release_version,
+            cohort,
+            mock_release_files_table_synid,
+            form=form,
+            column_mapping_table=column_mapping_table,
+            logger=mock_logger,
+        )
         # validate
-        mock_download_synapse_table.assert_called_with(syn, mock_release_files_table_synid)
+        mock_download_synapse_table.assert_called_with(
+            syn, mock_release_files_table_synid
+        )
         syn.get.assert_called_with(clinical_link_synid, followLink=True)
         mock_read_csv.assert_called_once_with(
             "path/to/clinical_file.csv", sep="\t", skiprows=4
         )
         pd.testing.assert_frame_equal(results, clinical_df_mock)
         mock_logger.info.assert_any_call(f"CLINICAL_FILE_LINK:{clinical_link_synid}")
-        mock_logger.info.assert_any_call(f"RELEASE_FILES_TABLE_SYNID:{mock_release_files_table_synid}")
+        mock_logger.info.assert_any_call(
+            f"RELEASE_FILES_TABLE_SYNID:{mock_release_files_table_synid}"
+        )
 
 
 @pytest.mark.parametrize(
-    "clinical_df_mock, form,clinical_link_synid",
+    "clinical_df_mock,cohort,form,clinical_link_synid",
     [
-        (pd.DataFrame(), "patient_characteristics", "syn34567"),
-        (pd.DataFrame(), "cancer_panel_test", "syn23456"),
+        (pd.DataFrame(), "NSCLC", "patient_characteristics", "syn34567"),
+        (pd.DataFrame(), "NSCLC", "cancer_panel_test", "syn23456"),
     ],
-    ids=["get_patient_file_empty", "get_sample_file_empty"]
+    ids=["get_patient_file_empty", "get_sample_file_empty"],
 )
 def test_get_main_genie_clinical_file_empty_file(
-    mock_synapse, mock_release_version, release_files_df, column_mapping_table, form, clinical_df_mock, clinical_link_synid
+    mock_synapse,
+    mock_release_version,
+    cohort,
+    release_files_df,
+    column_mapping_table,
+    form,
+    clinical_df_mock,
+    clinical_link_synid,
 ):
-    with patch.object(utilities, "download_synapse_table", return_value = release_files_df) as mock_download_synapse_table, patch.object(pandas,"read_csv", return_value=clinical_df_mock) as mock_read_csv, pytest.raises(ValueError, match=f"Clinical file pulled from {clinical_link_synid} link is empty."):
+    with patch.object(
+        utilities, "download_synapse_table", return_value=release_files_df
+    ) as mock_download_synapse_table, patch.object(
+        pandas, "read_csv", return_value=clinical_df_mock
+    ) as mock_read_csv, pytest.raises(
+        ValueError,
+        match=f"Clinical file pulled from {clinical_link_synid} link is empty.",
+    ):
         # Mock pandas.read_csv to return an empty DataFrame
         syn, mock_release_files_table_synid = mock_synapse
         mock_logger = MagicMock(spec=logging.Logger)
 
         # Call the function and assert the assertion error is raised
         results = get_main_genie_clinical_file(
-               syn, mock_release_version, mock_release_files_table_synid, form = form, column_mapping_table =column_mapping_table, logger = mock_logger
-            )
+            syn,
+            mock_release_version,
+            cohort,
+            mock_release_files_table_synid,
+            form=form,
+            column_mapping_table=column_mapping_table,
+            logger=mock_logger,
+        )
 
         # validate
-        mock_download_synapse_table.assert_called_with(syn, mock_release_files_table_synid)
+        mock_download_synapse_table.assert_called_with(
+            syn, mock_release_files_table_synid
+        )
         syn.get.assert_called_with(clinical_link_synid, followLink=True)
         mock_read_csv.assert_called_once_with(
             "path/to/clinical_file.csv", sep="\t", skiprows=4
         )
         pd.testing.assert_frame_equal(results, clinical_df_mock)
         mock_logger.info.assert_any_call(f"CLINICAL_FILE_LINK:{clinical_link_synid}")
-        mock_logger.info.assert_any_call(f"RELEASE_FILES_TABLE_SYNID:{mock_release_files_table_synid}")
+        mock_logger.info.assert_any_call(
+            f"RELEASE_FILES_TABLE_SYNID:{mock_release_files_table_synid}"
+        )
+
 
 @pytest.mark.parametrize(
-    "clinical_df_mock,form,clinical_link_synid,expected_cols",
+    "clinical_df_mock,cohort,form,clinical_link_synid,expected_cols",
     [
-        (pd.DataFrame({"col1": [1, 2, 3]}), "patient_characteristics", "syn34567","ETHNICITY_DETAILED,PRIMARY_RACE_DETAILED"),
-        (pd.DataFrame({"col1": [1, 2, 3]}), "cancer_panel_test", "syn23456","SEQ_YEAR"),
+        (
+            pd.DataFrame(
+                {
+                    "col1": [1, 2, 3],
+                    "ETHNICITY": ["enthnicity_1", "enthnicity_2", "enthnicity_3"],
+                    "PRIMARY_RACE": ["race_1", "race_2", "race_3"],
+                }
+            ),
+            "NSCLC",
+            "patient_characteristics",
+            "syn34567",
+            "ETHNICITY_DETAILED,PRIMARY_RACE_DETAILED",
+        ),
+        (
+            pd.DataFrame(
+                {
+                    "col1": [1, 2, 3],
+                    "SEQ_YEAR": ["year1", "year2", "year3"],
+                    "SAMPLE_TYPE": ["sample_type_1", "sample_type_2", "sample_type_3"],
+                }
+            ),
+            "NSCLC",
+            "cancer_panel_test",
+            "syn23456",
+            "SEQ_YEAR, SAMPLE_TYPE_DETAILED",
+        ),
     ],
-    ids=["get_patient_file", "get_sample_file"]
+    ids=["get_patient_file", "get_sample_file"],
 )
 def test_get_main_genie_clinical_file_no_req_cols(
-    mock_synapse, mock_release_version, release_files_df, column_mapping_table, form, clinical_df_mock, clinical_link_synid, expected_cols
+    mock_synapse,
+    mock_release_version,
+    cohort,
+    release_files_df,
+    column_mapping_table,
+    form,
+    clinical_df_mock,
+    clinical_link_synid,
+    expected_cols,
 ):
-    expected_error = (f"Clinical file pulled from {clinical_link_synid} link is missing an expected column. \\n"
-                     f"Expected columns: ['{expected_cols}']")
-    with patch.object(utilities, "download_synapse_table", return_value = release_files_df) as mock_download_synapse_table,patch.object(pandas,"read_csv", return_value=clinical_df_mock) as mock_read_csv,  pytest.raises(ValueError) as excinfo:
+    expected_error = (
+        f"Clinical file pulled from {clinical_link_synid} link is missing an expected column. \\n"
+        f"Expected columns: ['{expected_cols}']"
+    )
+    with patch.object(
+        utilities, "download_synapse_table", return_value=release_files_df
+    ) as mock_download_synapse_table, patch.object(
+        pandas, "read_csv", return_value=clinical_df_mock
+    ) as mock_read_csv, pytest.raises(
+        ValueError
+    ) as excinfo:
         syn, mock_release_files_table_synid = mock_synapse
         mock_logger = MagicMock(spec=logging.Logger)
 
         # Call the function and assert the assertion error is raised
         results = get_main_genie_clinical_file(
-               syn, mock_release_version, mock_release_files_table_synid, form = form, column_mapping_table =column_mapping_table, logger = mock_logger
-            )
+            syn,
+            mock_release_version,
+            cohort,
+            mock_release_files_table_synid,
+            form=form,
+            column_mapping_table=column_mapping_table,
+            logger=mock_logger,
+        )
         # validate
-        mock_download_synapse_table.assert_called_with(syn, mock_release_files_table_synid)
+        mock_download_synapse_table.assert_called_with(
+            syn, mock_release_files_table_synid
+        )
         syn.get.assert_called_with(clinical_link_synid, followLink=True)
         mock_read_csv.assert_called_once_with(
             "path/to/clinical_file.csv", sep="\t", skiprows=4
@@ -191,165 +382,506 @@ def test_get_main_genie_clinical_file_no_req_cols(
         pd.testing.assert_frame_equal(results, clinical_df_mock)
         assert str(excinfo.value) == expected_error
         mock_logger.info.assert_any_call(f"CLINICAL_FILE_LINK:{clinical_link_synid}")
-        mock_logger.info.assert_any_call(f"RELEASE_FILES_TABLE_SYNID:{mock_release_files_table_synid}")
+        mock_logger.info.assert_any_call(
+            f"RELEASE_FILES_TABLE_SYNID:{mock_release_files_table_synid}"
+        )
 
-@pytest.mark.skip(reason="This test is skipped because this integration test doesn't work in pytest env")
-def test_get_main_genie_clinical_sample_file_integration_test(config, column_mapping_table):
+
+@pytest.mark.skip(
+    reason="This test is skipped because this integration test doesn't work in pytest env"
+)
+def test_get_main_genie_clinical_sample_file_integration_test(
+    config, column_mapping_table
+):
     syn = synapseclient.login()
     get_main_genie_clinical_file(
-       syn,
-       release=config["main_genie_release_version"], 
-       release_files_table_synid=config["main_genie_data_release_files"], 
-       form = 'patient_characteristics', 
-       column_mapping_table =column_mapping_table, 
-       )
-    
+        syn,
+        release=config["main_genie_release_version"],
+        cohort="NSCLC",
+        release_files_table_synid=config["main_genie_data_release_files"],
+        form="patient_characteristics",
+        column_mapping_table=column_mapping_table,
+    )
+
+
 @pytest.mark.parametrize(
-    "form,bpc_column_list,expected_error",
+    "form,bpc_column_list,cohort, expected_error",
     [
-        ("patient_characteristics", ['other_col'], f"Invalid bpc_column_list. Column names should be matching ['naaccr_ethnicity_code', 'naaccr_race_code_primary']."),
-        ("cancer_panel_test", ['other_col'], f"Invalid bpc_column_list. Column names should be matching ['cpt_seq_date']."),
+        (
+            "patient_characteristics",
+            ["other_col"],
+            "",
+            f"Invalid bpc_column_list. Column names should be matching ['naaccr_ethnicity_code', 'naaccr_race_code_primary'].",
+        ),
+        (
+            "cancer_panel_test",
+            ["other_col"],
+            "",
+            f"Invalid bpc_column_list. Column names should be matching ['cpt_seq_date', 'cpt_sample_type'].",
+        ),
+        (
+            "patient_characteristics",
+            ["other_col"],
+            "CRC",
+            f"Invalid bpc_column_list. Column names should be matching ['naaccr_ethnicity_code', 'naaccr_race_code_primary'].",
+        ),
+        (
+            "cancer_panel_test",
+            ["other_col"],
+            "CRC",
+            f"Invalid bpc_column_list. Column names should be matching ['cpt_seq_date', 'cpt_sample_type'].",
+        ),
     ],
-    ids=["invalid_patient_col", "invalid_sample_col"]
+    ids=[
+        "invalid_patient_col_all_cohorts",
+        "invalid_sample_col_all_cohorts",
+        "invalid_patient_col_specific_cohort",
+        "invalid_sample_col_specific_cohort",
+    ],
 )
-def test_update_tier1a_invalid_bpc_column_list(syn, form, column_mapping_table, bpc_column_list, expected_error, config):
+def test_update_tier1a_invalid_bpc_column_list(
+    syn, form, column_mapping_table, bpc_column_list, cohort, expected_error, config
+):
     with pytest.raises(ValueError) as excinfo:
         mock_logger = MagicMock(spec=logging.Logger)
         master_table = MagicMock()
         main_genie_table = MagicMock()
 
-        update_tier1a(syn, form, master_table, main_genie_table, column_mapping_table, bpc_column_list, config, mock_logger)   
+        update_tier1a(
+            syn,
+            form,
+            master_table,
+            main_genie_table,
+            column_mapping_table,
+            bpc_column_list,
+            config,
+            mock_logger,
+            cohort,
+        )
 
         # validate
         assert str(excinfo.value) == expected_error
         mock_logger.assert_not_called()
 
+
 def get__update_tier1a_pass_all_cohorts_test_cases():
     return [
         {
-        "name": "update_patient_tier1_partial_col_all_cohorts",
-        "form": "patient_characteristics", 
-        "cpt_table_id": "syn123",
-        "main_genie_table": pd.DataFrame({"PATIENT_ID": ["GEN_1", "GEN_2"], "ETHNICITY_DETAILED": ["a", "b"],"PRIMARY_RACE_DETAILED": ["c", "d"], "OTHER_ID": ["test1", "test2"] }),
-        "cpt_table_schema": synapseclient.table.Schema(name='Patient Characteristics Table',parent="syn123456",column_names=["genie_patient_id", "naaccr_ethnicity_code", "naaccr_race_code_primary", "OTHER_ID"],column_types=["STRING", "STRING", "STRING","STRING"]),
-        "cpt_dat": pd.DataFrame({"genie_patient_id": ["GEN_1"], "naaccr_ethnicity_code": ["e"],"naaccr_race_code_primary": ["f"], "OTHER_ID": ["test3"]}, index=["indx"]),
-        "bpc_column_list": ["naaccr_ethnicity_code"],
-        "expected_cpt_seq_dat": pd.DataFrame({"naaccr_ethnicity_code": ["a"]},index = ["indx"]),
+            "name": "update_patient_tier1_partial_col_all_cohorts",
+            "form": "patient_characteristics",
+            "cpt_table_id": "syn123",
+            "main_genie_table": pd.DataFrame(
+                {
+                    "PATIENT_ID": ["GEN_1", "GEN_2"],
+                    "ETHNICITY_DETAILED": ["a", "b"],
+                    "PRIMARY_RACE_DETAILED": ["c", "d"],
+                    "OTHER_ID": ["test1", "test2"],
+                }
+            ),
+            "cpt_table_schema": synapseclient.table.Schema(
+                name="Patient Characteristics Table",
+                parent="syn123456",
+                column_names=[
+                    "genie_patient_id",
+                    "naaccr_ethnicity_code",
+                    "naaccr_race_code_primary",
+                    "OTHER_ID",
+                ],
+                column_types=["STRING", "STRING", "STRING", "STRING"],
+            ),
+            "cpt_dat": pd.DataFrame(
+                {
+                    "genie_patient_id": ["GEN_1"],
+                    "naaccr_ethnicity_code": ["e"],
+                    "naaccr_race_code_primary": ["f"],
+                    "OTHER_ID": ["test3"],
+                },
+                index=["indx"],
+            ),
+            "bpc_column_list": ["naaccr_ethnicity_code"],
+            "expected_cpt_seq_dat": pd.DataFrame(
+                {"naaccr_ethnicity_code": ["a"]}, index=["indx"]
+            ),
         },
         {
-        "name": "update_sample_tier1_col_all_cohorts",
-        "form": "cancer_panel_test", 
-        "cpt_table_id": "syn456",
-        "main_genie_table": pd.DataFrame({"SAMPLE_ID": ["GEN_1", "GEN_2"], "SEQ_YEAR": ["1111.0", "2222.0"],"SAMPLE_TYPE_DETAILED": ["c", "d"], "OTHER_ID": ["test1", "test2"] }),
-        "cpt_table_schema": synapseclient.table.Schema(name='Cancer Panel Test Table',parent="syn123456",column_names=["cpt_genie_sample_id", "cpt_seq_date", "cpt_sample_type", "OTHER_ID"],column_types=["STRING", "STRING", "STRING","STRING"]),
-        "cpt_dat": pd.DataFrame({"cpt_genie_sample_id": ["GEN_1", "GEN_2"], "cpt_seq_date": ["3333","4444"],"cpt_sample_type": ["e", "f"], "OTHER_ID": ["test3", "test4"] },index=["indx1","indx2"]),
-        "bpc_column_list": ["cpt_sample_type","cpt_seq_date"],
-        "expected_cpt_seq_dat": pd.DataFrame({"cpt_sample_type": ["c", "d"], "cpt_seq_date": ["1111", "2222"]},index=["indx1","indx2"]),
-        }
-
+            "name": "update_sample_tier1_col_all_cohorts",
+            "form": "cancer_panel_test",
+            "cpt_table_id": "syn456",
+            "main_genie_table": pd.DataFrame(
+                {
+                    "SAMPLE_ID": ["GEN_1", "GEN_2"],
+                    "SEQ_YEAR": ["1111.0", "2222.0"],
+                    "SAMPLE_TYPE_DETAILED": ["c", "d"],
+                    "OTHER_ID": ["test1", "test2"],
+                }
+            ),
+            "cpt_table_schema": synapseclient.table.Schema(
+                name="Cancer Panel Test Table",
+                parent="syn123456",
+                column_names=[
+                    "cpt_genie_sample_id",
+                    "cpt_seq_date",
+                    "cpt_sample_type",
+                    "OTHER_ID",
+                ],
+                column_types=["STRING", "STRING", "STRING", "STRING"],
+            ),
+            "cpt_dat": pd.DataFrame(
+                {
+                    "cpt_genie_sample_id": ["GEN_1", "GEN_2"],
+                    "cpt_seq_date": ["3333", "4444"],
+                    "cpt_sample_type": ["e", "f"],
+                    "OTHER_ID": ["test3", "test4"],
+                },
+                index=["indx1", "indx2"],
+            ),
+            "bpc_column_list": ["cpt_sample_type", "cpt_seq_date"],
+            "expected_cpt_seq_dat": pd.DataFrame(
+                {"cpt_sample_type": ["c", "d"], "cpt_seq_date": ["1111", "2222"]},
+                index=["indx1", "indx2"],
+            ),
+        },
     ]
 
+
 @pytest.mark.parametrize(
-    "test_cases", get__update_tier1a_pass_all_cohorts_test_cases(), ids=lambda x: x["name"]
+    "test_cases",
+    get__update_tier1a_pass_all_cohorts_test_cases(),
+    ids=lambda x: x["name"],
 )
-def test_update_tier1a_pass_all_cohorts(syn, test_cases, master_table, column_mapping_table, config):
-    with patch.object(utilities, "download_synapse_table", return_value = test_cases["cpt_dat"]) as mock_download_synapse_table, patch.object(syn, "tableQuery") as patch_table_query, patch.object(utilities, "update_tier1a_data_replacement_mapping_table", return_value = None) as mock_update_tier1a:
+def test_update_tier1a_pass_all_cohorts(
+    syn, test_cases, master_table, column_mapping_table, config
+):
+    with patch.object(
+        utilities, "download_synapse_table", return_value=test_cases["cpt_dat"]
+    ) as mock_download_synapse_table, patch.object(
+        syn, "tableQuery"
+    ) as patch_table_query, patch.object(
+        utilities, "update_tier1a_data_replacement_mapping_table", return_value=None
+    ) as mock_update_tier1a:
         logger = MagicMock(spec=logging.Logger)
 
         # call the function
-        table_id, cpt_seq_dat = update_tier1a(syn, test_cases["form"], master_table, test_cases["main_genie_table"], column_mapping_table, test_cases["bpc_column_list"], config, logger)
-        #import pdb; pdb.set_trace()
+        table_id, cpt_seq_dat = update_tier1a(
+            syn,
+            test_cases["form"],
+            master_table,
+            test_cases["main_genie_table"],
+            column_mapping_table,
+            test_cases["bpc_column_list"],
+            config,
+            logger,
+        )
+
         # validate
-        logger.info.assert_called_with(f"Update {test_cases['bpc_column_list']} in {test_cases['form']}")
+        logger.info.assert_called_with(
+            f"Update {test_cases['bpc_column_list']} in {test_cases['form']}"
+        )
         mock_update_tier1a.assert_called_once()
         mock_download_synapse_table.assert_called_with(syn, test_cases["cpt_table_id"])
         assert table_id == test_cases["cpt_table_id"]
         pd.testing.assert_frame_equal(cpt_seq_dat, test_cases["expected_cpt_seq_dat"])
 
+
 def get__update_tier1a_pass_cohort_specific_test_cases():
     return [
         {
-        "name": "update_patient_tier1_partial_col_cohort",
-        "form": "patient_characteristics",
-        "cpt_table_id": "syn123",
-        "main_genie_table": pd.DataFrame({"PATIENT_ID": ["GEN_1", "GEN_3"], "ETHNICITY_DETAILED": ["a", "b"],"PRIMARY_RACE_DETAILED": ["c", "d"], "OTHER_ID": ["test1", "test2"] }),
-        "cpt_table_schema": synapseclient.table.Schema(name='Patient Characteristics Table',parent="syn123456",column_names=["genie_patient_id", "naaccr_ethnicity_code", "naaccr_race_code_primary", "OTHER_ID"],column_types=["STRING", "STRING", "STRING","STRING"]),
-        "cpt_dat": pd.DataFrame({"genie_patient_id": ["GEN_1", "GEN_2"], "naaccr_ethnicity_code": ["e", "f"],"naaccr_race_code_primary": ["g", "h"], "cohort": ["cohort1", "cohort1"],"OTHER_ID": ["test3", "test4"] }, index=["indx1", "indx2"]),
-        "bpc_column_list": ["naaccr_ethnicity_code"],
-        "expected_cpt_seq_dat": pd.DataFrame({"naaccr_ethnicity_code": ["a",np.nan]},index = ["indx1", "indx2"]),
-        "cohort": "cohort1"
+            "name": "update_patient_tier1_partial_col_cohort_detailed_col",
+            "form": "patient_characteristics",
+            "cpt_table_id": "syn123",
+            "main_genie_table": pd.DataFrame(
+                {
+                    "PATIENT_ID": ["GEN_1", "GEN_3"],
+                    "ETHNICITY_DETAILED": ["a", "b"],
+                    "PRIMARY_RACE_DETAILED": ["c", "d"],
+                    "ETHNICITY": ["r", "s"],
+                    "PRIMARY_RACE": ["t", "u"],
+                    "CENTER": ["NSCLC", "CRC"],
+                    "OTHER_ID": ["test1", "test2"],
+                }
+            ),
+            "cpt_table_schema": synapseclient.table.Schema(
+                name="Patient Characteristics Table",
+                parent="syn123456",
+                column_names=[
+                    "genie_patient_id",
+                    "naaccr_ethnicity_code",
+                    "naaccr_race_code_primary",
+                    "OTHER_ID",
+                ],
+                column_types=["STRING", "STRING", "STRING", "STRING"],
+            ),
+            "cpt_dat": pd.DataFrame(
+                {
+                    "genie_patient_id": ["GEN_1", "GEN_2"],
+                    "naaccr_ethnicity_code": ["e", "f"],
+                    "naaccr_race_code_primary": ["g", "h"],
+                    "cohort": ["NSCLC", "NSCLC"],
+                    "OTHER_ID": ["test3", "test4"],
+                },
+                index=["indx1", "indx2"],
+            ),
+            "bpc_column_list": ["naaccr_ethnicity_code"],
+            "expected_cpt_seq_dat": pd.DataFrame(
+                {"naaccr_ethnicity_code": ["a", np.nan]}, index=["indx1", "indx2"]
+            ),
+            "cohort": "NSCLC",
         },
         {
-        "name": "update_sample_tier1_col_cohort",
-        "form": "cancer_panel_test", 
-        "cpt_table_id": "syn456",
-        "main_genie_table": pd.DataFrame({"SAMPLE_ID": ["GEN_1", "GEN_2"], "SEQ_YEAR": ["1111.0", "2222.0"],"SAMPLE_TYPE_DETAILED": ["c", "d"], "OTHER_ID": ["test1", "test2"] }),
-        "cpt_table_schema": synapseclient.table.Schema(name='Cancer Panel Test Table',parent="syn123456",column_names=["cpt_genie_sample_id", "cpt_seq_date", "cpt_sample_type", "OTHER_ID"],column_types=["STRING", "STRING", "STRING","STRING"]),
-        "cpt_dat": pd.DataFrame({"cpt_genie_sample_id": ["GEN_1", "GEN_2"], "cpt_seq_date": ["3333","4444"],"cpt_sample_type": ["e", "f"],  "cohort": ["cohort1", "cohort1"],"OTHER_ID": ["test3", "test4"] },index=["indx1","indx2"]),
-        "bpc_column_list": ["cpt_sample_type","cpt_seq_date"],
-        "expected_cpt_seq_dat": pd.DataFrame({"cpt_sample_type": ["c", "d"], "cpt_seq_date": ["1111", "2222"]},index=["indx1","indx2"]),
-        "cohort": "cohort1"
-        }
+            "name": "update_sample_tier1_col_cohort_detailed_col",
+            "form": "cancer_panel_test",
+            "cpt_table_id": "syn456",
+            "main_genie_table": pd.DataFrame(
+                {
+                    "SAMPLE_ID": ["GEN_1", "GEN_2"],
+                    "SEQ_YEAR": ["1111.0", "2222.0"],
+                    "SAMPLE_TYPE_DETAILED": ["c", "d"],
+                    "SAMPLE_TYPE": ["g", "h"],
+                    "CENTER": ["NSCLC", "NSCLC"],
+                    "OTHER_ID": ["test1", "test2"],
+                }
+            ),
+            "cpt_table_schema": synapseclient.table.Schema(
+                name="Cancer Panel Test Table",
+                parent="syn123456",
+                column_names=[
+                    "cpt_genie_sample_id",
+                    "cpt_seq_date",
+                    "cpt_sample_type",
+                    "OTHER_ID",
+                ],
+                column_types=["STRING", "STRING", "STRING", "STRING"],
+            ),
+            "cpt_dat": pd.DataFrame(
+                {
+                    "cpt_genie_sample_id": ["GEN_1", "GEN_2"],
+                    "cpt_seq_date": ["3333", "4444"],
+                    "cpt_sample_type": ["e", "f"],
+                    "cohort": ["NSCLC", "NSCLC"],
+                    "OTHER_ID": ["test3", "test4"],
+                },
+                index=["indx1", "indx2"],
+            ),
+            "bpc_column_list": ["cpt_sample_type", "cpt_seq_date"],
+            "expected_cpt_seq_dat": pd.DataFrame(
+                {"cpt_sample_type": ["c", "d"], "cpt_seq_date": ["1111", "2222"]},
+                index=["indx1", "indx2"],
+            ),
+            "cohort": "NSCLC",
+        },
+        {
+            "name": "update_patient_tier1_partial_col_cohort_non_detailed_col",
+            "form": "patient_characteristics",
+            "cpt_table_id": "syn123",
+            "main_genie_table": pd.DataFrame(
+                {
+                    "PATIENT_ID": ["GEN_1", "GEN_3"],
+                    "ETHNICITY_DETAILED": ["a", "b"],
+                    "PRIMARY_RACE_DETAILED": ["c", "d"],
+                    "ETHNICITY": ["r", "s"],
+                    "PRIMARY_RACE": ["t", "u"],
+                    "CENTER": ["NSCLC", "CRC"],
+                    "OTHER_ID": ["test1", "test2"],
+                }
+            ),
+            "cpt_table_schema": synapseclient.table.Schema(
+                name="Patient Characteristics Table",
+                parent="syn123456",
+                column_names=[
+                    "genie_patient_id",
+                    "naaccr_ethnicity_code",
+                    "naaccr_race_code_primary",
+                    "OTHER_ID",
+                ],
+                column_types=["STRING", "STRING", "STRING", "STRING"],
+            ),
+            "cpt_dat": pd.DataFrame(
+                {
+                    "genie_patient_id": ["GEN_1", "GEN_2"],
+                    "naaccr_ethnicity_code": ["e", "f"],
+                    "naaccr_race_code_primary": ["g", "h"],
+                    "cohort": ["CRC", "CRC"],
+                    "OTHER_ID": ["test3", "test4"],
+                },
+                index=["indx1", "indx2"],
+            ),
+            "bpc_column_list": ["naaccr_ethnicity_code"],
+            "expected_cpt_seq_dat": pd.DataFrame(
+                {"naaccr_ethnicity_code": ["r", np.nan]}, index=["indx1", "indx2"]
+            ),
+            "cohort": "CRC",
+        },
+        {
+            "name": "update_sample_tier1_col_cohort_non_detailed_col",
+            "form": "cancer_panel_test",
+            "cpt_table_id": "syn456",
+            "main_genie_table": pd.DataFrame(
+                {
+                    "SAMPLE_ID": ["GEN_1", "GEN_2", "GEN_3"],
+                    "SEQ_YEAR": ["1111.0", "2222.0", "3333.0"],
+                    "SAMPLE_TYPE_DETAILED": ["c", "d", "e"],
+                    "SAMPLE_TYPE": ["g", "h", "i"],
+                    "CENTER": ["CRC", "CRC", "NSCLC"],
+                    "OTHER_ID": ["test1", "test2", "test3"],
+                }
+            ),
+            "cpt_table_schema": synapseclient.table.Schema(
+                name="Cancer Panel Test Table",
+                parent="syn123456",
+                column_names=[
+                    "cpt_genie_sample_id",
+                    "cpt_seq_date",
+                    "cpt_sample_type",
+                    "OTHER_ID",
+                ],
+                column_types=["STRING", "STRING", "STRING", "STRING"],
+            ),
+            "cpt_dat": pd.DataFrame(
+                {
+                    "cpt_genie_sample_id": ["GEN_1", "GEN_2"],
+                    "cpt_seq_date": ["3333", "4444"],
+                    "cpt_sample_type": ["e", "f"],
+                    "cohort": ["CRC", "CRC"],
+                    "OTHER_ID": ["test3", "test4"],
+                },
+                index=["indx1", "indx2"],
+            ),
+            "bpc_column_list": ["cpt_sample_type", "cpt_seq_date"],
+            "expected_cpt_seq_dat": pd.DataFrame(
+                {"cpt_sample_type": ["g", "h"], "cpt_seq_date": ["1111", "2222"]},
+                index=["indx1", "indx2"],
+            ),
+            "cohort": "CRC",
+        },
     ]
 
+
 @pytest.mark.parametrize(
-    "test_cases", get__update_tier1a_pass_cohort_specific_test_cases(), ids=lambda x: x["name"]
+    "test_cases",
+    get__update_tier1a_pass_cohort_specific_test_cases(),
+    ids=lambda x: x["name"],
 )
-def test_update_tier1a_pass_cohort_specific(syn, test_cases, master_table, column_mapping_table, config):
-    with patch.object(utilities, "download_synapse_table", return_value = test_cases["cpt_dat"]) as mock_download_synapse_table, patch.object(syn, "tableQuery") as patch_table_query, patch.object(utilities, "update_tier1a_data_replacement_mapping_table", return_value = None) as mock_update_tier1a:
+def test_update_tier1a_pass_cohort_specific(
+    syn, test_cases, master_table, column_mapping_table, config
+):
+    with patch.object(
+        utilities, "download_synapse_table", return_value=test_cases["cpt_dat"]
+    ) as mock_download_synapse_table, patch.object(
+        syn, "tableQuery"
+    ) as patch_table_query, patch.object(
+        utilities, "update_tier1a_data_replacement_mapping_table", return_value=None
+    ) as mock_update_tier1a:
         logger = MagicMock(spec=logging.Logger)
         # call the function
-        table_id, cpt_seq_dat = update_tier1a(syn, test_cases["form"], master_table, test_cases["main_genie_table"], column_mapping_table, test_cases["bpc_column_list"], config, logger, test_cases["cohort"])
+        table_id, cpt_seq_dat = update_tier1a(
+            syn,
+            test_cases["form"],
+            master_table,
+            test_cases["main_genie_table"],
+            column_mapping_table,
+            test_cases["bpc_column_list"],
+            config,
+            logger,
+            test_cases["cohort"],
+        )
 
         # validate
-        logger.info.assert_called_with(f"Update {test_cases['bpc_column_list']} in {test_cases['form']}")
+        logger.info.assert_called_with(
+            f"Update {test_cases['bpc_column_list']} in {test_cases['form']}"
+        )
         if test_cases["form"] == "patient_characteristics":
-            logger.warning.assert_called_with("Missing GEN_2 in main GENIE table. Please be advised that tier 1a fields for these records will be filled with NaN.")
+            logger.warning.assert_called_with(
+                "Missing GEN_2 in main GENIE table. Please be advised that tier 1a fields for these records will be filled with NaN."
+            )
         mock_update_tier1a.assert_called_once()
-        mock_download_synapse_table.assert_called_with(syn, test_cases["cpt_table_id"], condition="cohort = 'cohort1'")
+        mock_download_synapse_table.assert_called_with(
+            syn,
+            test_cases["cpt_table_id"],
+            condition=f"cohort = '{test_cases['cohort']}'",
+        )
         assert table_id == test_cases["cpt_table_id"]
         pd.testing.assert_frame_equal(cpt_seq_dat, test_cases["expected_cpt_seq_dat"])
+
 
 def get__overwrite_tier1a_test_cases():
     return [
         {
-        "name": "overwrite_patient_tier1",
-        "form": "patient_characteristics",
-        "cpt_table_id": "syn123",
-        "cpt_table_schema": synapseclient.table.Schema(name='Patient Characteristics Table',parent="syn123456",column_names=["genie_patient_id", "naaccr_ethnicity_code", "naaccr_race_code_primary", "OTHER_ID"],column_types=["STRING", "STRING", "STRING","STRING"]),
-        "bpc_column_list": ["naaccr_ethnicity_code"],
-        "cpt_seq_dat": pd.DataFrame({"naaccr_ethnicity_code": ["a"]},index = ["indx"]),
+            "name": "overwrite_patient_tier1",
+            "form": "patient_characteristics",
+            "cpt_table_id": "syn123",
+            "cpt_table_schema": synapseclient.table.Schema(
+                name="Patient Characteristics Table",
+                parent="syn123456",
+                column_names=[
+                    "genie_patient_id",
+                    "naaccr_ethnicity_code",
+                    "naaccr_race_code_primary",
+                    "OTHER_ID",
+                ],
+                column_types=["STRING", "STRING", "STRING", "STRING"],
+            ),
+            "bpc_column_list": ["naaccr_ethnicity_code"],
+            "cpt_seq_dat": pd.DataFrame(
+                {"naaccr_ethnicity_code": ["a"]}, index=["indx"]
+            ),
         },
         {
-        "name": "overwrite_sample_tier1",
-        "form": "cancer_panel_test",
-        "cpt_table_id": "syn456",
-        "cpt_table_schema": synapseclient.table.Schema(name='Cancer Panel Test Table',parent="syn123456",column_names=["cpt_genie_sample_id", "cpt_seq_date", "cpt_sample_type", "OTHER_ID"],column_types=["STRING", "STRING", "STRING","STRING"]),
-        "bpc_column_list": ["cpt_sample_type","cpt_seq_date"],
-        "cpt_seq_dat": pd.DataFrame({"cpt_sample_type": ["c", "d"], "cpt_seq_date": ["1111", "2222"]},index=["indx1","indx2"]),
-        }
+            "name": "overwrite_sample_tier1",
+            "form": "cancer_panel_test",
+            "cpt_table_id": "syn456",
+            "cpt_table_schema": synapseclient.table.Schema(
+                name="Cancer Panel Test Table",
+                parent="syn123456",
+                column_names=[
+                    "cpt_genie_sample_id",
+                    "cpt_seq_date",
+                    "cpt_sample_type",
+                    "OTHER_ID",
+                ],
+                column_types=["STRING", "STRING", "STRING", "STRING"],
+            ),
+            "bpc_column_list": ["cpt_sample_type", "cpt_seq_date"],
+            "cpt_seq_dat": pd.DataFrame(
+                {"cpt_sample_type": ["c", "d"], "cpt_seq_date": ["1111", "2222"]},
+                index=["indx1", "indx2"],
+            ),
+        },
     ]
+
 
 @pytest.mark.parametrize(
     "test_cases", get__overwrite_tier1a_test_cases(), ids=lambda x: x["name"]
 )
 def test_overwrite_tier1a(syn, test_cases):
-    with patch.object(syn, "tableQuery") as patch_table_query, patch.object(syn, "store") as patch_store:
+    with patch.object(syn, "tableQuery") as patch_table_query, patch.object(
+        syn, "store"
+    ) as patch_store:
         logger = MagicMock(spec=logging.Logger)
-        syn.get = MagicMock(return_value = test_cases["cpt_table_schema"])
-        patch_table_query.return_value =  MagicMock(etag = "test_etag")
-        
+        syn.get = MagicMock(return_value=test_cases["cpt_table_schema"])
+        patch_table_query.return_value = MagicMock(etag="test_etag")
+
         # call the function
-        overwrite_tier1a(syn, test_cases["form"], test_cases["cpt_table_id"], test_cases["cpt_seq_dat"], test_cases["bpc_column_list"], logger)
+        overwrite_tier1a(
+            syn,
+            test_cases["form"],
+            test_cases["cpt_table_id"],
+            test_cases["cpt_seq_dat"],
+            test_cases["bpc_column_list"],
+            logger,
+        )
 
         # validate
-        logger.info.assert_called_with(f"Overwrite {test_cases['bpc_column_list']} in {test_cases['form']}")
+        logger.info.assert_called_with(
+            f"Overwrite {test_cases['bpc_column_list']} in {test_cases['form']}"
+        )
         syn.get.assert_called_with(test_cases["cpt_table_id"])
         syn.tableQuery.assert_called_with(f"SELECT * FROM {test_cases['cpt_table_id']}")
         args, kwargs = patch_store.call_args
         stored_table = args[0]
         assert stored_table.schema == test_cases["cpt_table_schema"]
-        pd.testing.assert_frame_equal(stored_table.asDataFrame(), test_cases["cpt_seq_dat"].reset_index(drop=True))
+        pd.testing.assert_frame_equal(
+            stored_table.asDataFrame(), test_cases["cpt_seq_dat"].reset_index(drop=True)
+        )
         assert stored_table.etag == "test_etag"
 
 
@@ -357,50 +889,55 @@ def test_overwrite_tier1a(syn, test_cases):
     "left_table,right_table,left_on,right_on",
     [
         (
-        pd.DataFrame({'ID': [1, 2, 3], 'Value1': ['A', 'B', 'C']}),
-        pd.DataFrame({'ID': [1, 4, 5], 'Value2': ['X', 'Y', 'Z']}),
-        "ID",
-        "ID"
+            pd.DataFrame({"ID": [1, 2, 3], "Value1": ["A", "B", "C"]}),
+            pd.DataFrame({"ID": [1, 4, 5], "Value2": ["X", "Y", "Z"]}),
+            "ID",
+            "ID",
         ),
         (
-        pd.DataFrame({'ID_1': [1, 2, 3], 'Value1': ['A', 'B', 'C']}),
-        pd.DataFrame({'ID_2': [1, 4, 5], 'Value2': ['X', 'Y', 'Z']}),
-        "ID_1",
-        "ID_2"
+            pd.DataFrame({"ID_1": [1, 2, 3], "Value1": ["A", "B", "C"]}),
+            pd.DataFrame({"ID_2": [1, 4, 5], "Value2": ["X", "Y", "Z"]}),
+            "ID_1",
+            "ID_2",
         ),
-
     ],
-    ids=["same_join_key_name", "diff_join_key_name"]
-
+    ids=["same_join_key_name", "diff_join_key_name"],
 )
-def test_check_if_all_join_keys_available_fail(left_table, right_table, left_on, right_on):
+def test_check_if_all_join_keys_available_fail(
+    left_table, right_table, left_on, right_on
+):
     logger = MagicMock(spec=logging.Logger)
     logger.warning = MagicMock()
     # call the function
     check_if_all_join_keys_available(left_table, right_table, left_on, right_on, logger)
 
     #  validate
-    logger.warning.assert_called_with("Missing 2, 3 in main GENIE table. Please be advised that tier 1a fields for these records will be filled with NaN.")
+    logger.warning.assert_called_with(
+        "Missing 2, 3 in main GENIE table. Please be advised that tier 1a fields for these records will be filled with NaN."
+    )
+
 
 @pytest.mark.parametrize(
     "left_table,right_table,left_on,right_on",
     [
         (
-        pd.DataFrame({'ID': [1, 2, 3], 'Value1': ['A', 'B', 'C']}),
-        pd.DataFrame({'ID': [1, 2, 3], 'Value2': ['X', 'Y', 'Z']}),
-        "ID",
-        "ID"
+            pd.DataFrame({"ID": [1, 2, 3], "Value1": ["A", "B", "C"]}),
+            pd.DataFrame({"ID": [1, 2, 3], "Value2": ["X", "Y", "Z"]}),
+            "ID",
+            "ID",
         ),
         (
-        pd.DataFrame({'ID_1': [1, 2, 3], 'Value1': ['A', 'B', 'C']}),
-        pd.DataFrame({'ID_2': [1, 2, 3], 'Value2': ['X', 'Y', 'Z']}),
-        "ID_1",
-        "ID_2"
-        )
+            pd.DataFrame({"ID_1": [1, 2, 3], "Value1": ["A", "B", "C"]}),
+            pd.DataFrame({"ID_2": [1, 2, 3], "Value2": ["X", "Y", "Z"]}),
+            "ID_1",
+            "ID_2",
+        ),
     ],
-    ids=["same_join_key_name", "diff_join_key_name"]
+    ids=["same_join_key_name", "diff_join_key_name"],
 )
-def test_check_if_all_join_keys_available_pass(left_table, right_table, left_on, right_on):
+def test_check_if_all_join_keys_available_pass(
+    left_table, right_table, left_on, right_on
+):
     logger = MagicMock(spec=logging.Logger)
     logger.warning = MagicMock()
     check_if_all_join_keys_available(left_table, right_table, left_on, right_on, logger)

--- a/scripts/table_updates/update_data_table.py
+++ b/scripts/table_updates/update_data_table.py
@@ -27,8 +27,15 @@ import numpy
 import pandas
 import synapseclient
 import utilities
-from synapseclient import (Column, Row, RowSet, Schema, Table,
-                           as_table_columns, build_table)
+from synapseclient import (
+    Column,
+    Row,
+    RowSet,
+    Schema,
+    Table,
+    as_table_columns,
+    build_table,
+)
 
 TABLES = {
     "production": {
@@ -46,6 +53,7 @@ TABLES = {
 def get_main_genie_clinical_file(
     syn: synapseclient.Synapse,
     release: str,
+    cohort: str,
     release_files_table_synid: str,
     form: str,
     column_mapping_table: pandas.DataFrame,
@@ -56,6 +64,7 @@ def get_main_genie_clinical_file(
     Args:
         syn (synapseclient.Synapse): synapse client connection
         release (str): release version to pull from for main genie
+        cohort (str): cohort name
         release_files_table_synid (str): synapse id of the data relese files table
         from main genie
         form (str): form name, can be either patient_characteristics or cancer_panel_test
@@ -80,10 +89,14 @@ def get_main_genie_clinical_file(
     clinical_df = pandas.read_csv(clinical_ent.path, sep="\t", skiprows=4)
     # get column list for the form
     column_list = column_mapping_table.loc[
-        column_mapping_table["prissmm_form"] == form,
+        (column_mapping_table["prissmm_form"] == form)
+        & (column_mapping_table["main_genie_release"] == release)
+        & (column_mapping_table["cohort"] == cohort),
     ].genie_element.to_list()
     if clinical_df.empty:
-        raise ValueError(f"Clinical file pulled from {clinical_link_synid} link is empty.")
+        raise ValueError(
+            f"Clinical file pulled from {clinical_link_synid} link is empty."
+        )
     if not set(column_list) < set(clinical_df.columns):
         raise ValueError(
             f"Clinical file pulled from {clinical_link_synid} link is missing an expected column. \n"
@@ -502,11 +515,20 @@ def update_tier1a(
         Tuple[str, pandas.DataFrame]: The synapse ID for BPC table to be modified and the updated table as dataframe
     """
     # check the validity of bpc_column_list
-    valid_col = column_mapping_table.loc[
-        column_mapping_table["prissmm_form"] == form,
-    ].prissmm_element.tolist()
+    subset_column_mapping_table = column_mapping_table.loc[
+        (column_mapping_table["prissmm_form"] == form)
+        & (
+            column_mapping_table["main_genie_release"]
+            == config["main_genie_release_version"]
+        )
+        & (column_mapping_table["cohort"] == cohort),
+    ]
+    valid_col = subset_column_mapping_table.prissmm_element.tolist()
+    # import pdb; pdb.set_trace()
     if not all(item in valid_col for item in bpc_column_list):
-        raise ValueError(f"Invalid bpc_column_list. Column names should be matching {valid_col}.")
+        raise ValueError(
+            f"Invalid bpc_column_list. Column names should be matching {valid_col}."
+        )
 
     logger.info(f"Update {bpc_column_list} in {form}")
     # load bpc table
@@ -523,11 +545,9 @@ def update_tier1a(
     cpt_dat["index"] = cpt_dat.index
     # subset main_genie_table based on bpc_column_list
     main_genie_column_list = [
-        ", ".join(
-            column_mapping_table.loc[
-                column_mapping_table["prissmm_element"] == col,
-            ].genie_element
-        )
+        subset_column_mapping_table.loc[
+            subset_column_mapping_table["prissmm_element"] == col, "genie_element"
+        ].values[0]
         for col in bpc_column_list
     ]
 
@@ -564,7 +584,17 @@ def update_tier1a(
             left_on="cpt_genie_sample_id",
             right_on="SAMPLE_ID",
         )
-    utilities.update_tier1a_data_replacement_mapping_table(syn, merged_table = cpt_seq_dat, form = form, config = config, comment = comment, logger = logger, bpc_column_list = bpc_column_list, main_genie_column_list = main_genie_column_list, cohort = cohort)
+    utilities.update_tier1a_data_replacement_mapping_table(
+        syn,
+        merged_table=cpt_seq_dat,
+        form=form,
+        config=config,
+        comment=comment,
+        logger=logger,
+        bpc_column_list=bpc_column_list,
+        main_genie_column_list=main_genie_column_list,
+        cohort=cohort,
+    )
     # reformat the columns
     cpt_seq_dat.index = cpt_seq_dat["index"]
     cpt_seq_dat.index.name = None
@@ -610,8 +640,8 @@ def custom_fix_for_tier1a_variable(
     logger: logging.Logger,
     config: dict,
     cohort: str = "",
-    replace_patient_tier1a: bool = False, 
-    replace_sample_tier1a: bool = False, 
+    replace_patient_tier1a: bool = False,
+    replace_sample_tier1a: bool = False,
     comment: str = "",
 ) -> None:
     """
@@ -628,8 +658,8 @@ def custom_fix_for_tier1a_variable(
         comment (str): version comment
     """
     # BUG: unlist form column in master table only works for STAGING table
-    #master_table["form"] = master_table["form"].apply(lambda x: ", ".join(x))
-    
+    # master_table["form"] = master_table["form"].apply(lambda x: ", ".join(x))
+
     # load GENIE BPC elements mapping table
     column_mapping_table = utilities.download_synapse_table(syn, "syn20945902")
 
@@ -639,6 +669,7 @@ def custom_fix_for_tier1a_variable(
         genie_patient_dat = get_main_genie_clinical_file(
             syn,
             release=config["main_genie_release_version"],
+            cohort=cohort,
             release_files_table_synid=config["main_genie_data_release_files"],
             form="patient_characteristics",
             column_mapping_table=column_mapping_table,
@@ -651,18 +682,18 @@ def custom_fix_for_tier1a_variable(
             master_table,
             genie_patient_dat,
             column_mapping_table,
-            bpc_column_list= config['patient_tier1a_column_list_to_be_replaced'],
+            bpc_column_list=config["patient_tier1a_column_list_to_be_replaced"],
             config=config,
             logger=logger,
             cohort=cohort,
-            comment=comment
+            comment=comment,
         )
         overwrite_tier1a(
             syn,
             "patient_characteristics",
             cpt_table_id,
             cpt_seq_dat,
-            bpc_column_list=config['patient_tier1a_column_list_to_be_replaced'],
+            bpc_column_list=config["patient_tier1a_column_list_to_be_replaced"],
             logger=logger,
         )
         logger.info("Overwrite tier1a patient variables completed!")
@@ -672,11 +703,12 @@ def custom_fix_for_tier1a_variable(
         genie_sample_dat = get_main_genie_clinical_file(
             syn,
             release=config["main_genie_release_version"],
+            cohort=cohort,
             release_files_table_synid=config["main_genie_data_release_files"],
             form="cancer_panel_test",
             column_mapping_table=column_mapping_table,
             logger=logger,
-    )
+        )
         # modify for sample table
         cpt_table_id, cpt_seq_dat = update_tier1a(
             syn,
@@ -688,7 +720,7 @@ def custom_fix_for_tier1a_variable(
             config=config,
             logger=logger,
             cohort=cohort,
-            comment=comment
+            comment=comment,
         )
         overwrite_tier1a(
             syn,
@@ -698,23 +730,24 @@ def custom_fix_for_tier1a_variable(
             bpc_column_list=config["sample_tier1a_column_list_to_be_replaced"],
             logger=logger,
         )
-        logger.info("Overwrite tier1a sample variables completed!")            
+        logger.info("Overwrite tier1a sample variables completed!")
+
 
 def custom_fix_for_cpt_seq_data(
-        syn: synapseclient.Synapse,
-        master_table: pandas.DataFrame,
-        logger: logging.Logger,
-        config: dict,
-        cohort: str = "",
-        comment: str = "",
-        replace_patient_tier1a: bool = False, 
-        replace_sample_tier1a: bool = False, 
-    ) -> None:
+    syn: synapseclient.Synapse,
+    master_table: pandas.DataFrame,
+    logger: logging.Logger,
+    config: dict,
+    cohort: str = "",
+    comment: str = "",
+    replace_patient_tier1a: bool = False,
+    replace_sample_tier1a: bool = False,
+) -> None:
     # BUG: unlist form column in master table only when not replacing tier1a variables
     # works only for STAGING table
-    #if not (replace_patient_tier1a or replace_sample_tier1a):
+    # if not (replace_patient_tier1a or replace_sample_tier1a):
     #    master_table["form"] = master_table["form"].apply(lambda x: ", ".join(x))
-    
+
     # load GENIE BPC elements mapping table
     column_mapping_table = utilities.download_synapse_table(syn, "syn20945902")
 
@@ -722,11 +755,12 @@ def custom_fix_for_cpt_seq_data(
     genie_sample_dat = get_main_genie_clinical_file(
         syn,
         release=config["main_genie_release_version"],
+        cohort=cohort,
         release_files_table_synid=config["main_genie_data_release_files"],
         form="cancer_panel_test",
         column_mapping_table=column_mapping_table,
         logger=logger,
-        )
+    )
     # modify for sample table
     cpt_table_id, cpt_seq_dat = update_tier1a(
         syn,
@@ -738,10 +772,12 @@ def custom_fix_for_cpt_seq_data(
         config=config,
         logger=logger,
         cohort=cohort,
-        comment=comment
+        comment=comment,
     )
     # reformat cpt_seq_date column
-    cpt_seq_dat["cpt_seq_date"] = cpt_seq_dat["cpt_seq_date"].map(utilities.float_to_int)
+    cpt_seq_dat["cpt_seq_date"] = cpt_seq_dat["cpt_seq_date"].map(
+        utilities.float_to_int
+    )
     overwrite_tier1a(
         syn,
         "cancer_panel_test",
@@ -751,7 +787,8 @@ def custom_fix_for_cpt_seq_data(
         logger=logger,
     )
 
-    logger.info("Overwrite cpt_seq_date completed!")            
+    logger.info("Overwrite cpt_seq_date completed!")
+
 
 def main():
     # add arguments
@@ -788,14 +825,14 @@ def main():
     parser.add_argument(
         "-rp",
         "--replace_patient_tier1a",
-        type = lambda x: x.lower()== 'true',
+        type=lambda x: x.lower() == "true",
         default=False,
         help="Whether to replace tier1a variables in patient_characteristics table",
     )
     parser.add_argument(
         "-rs",
         "--replace_sample_tier1a",
-        type = lambda x: x.lower()== 'true',
+        type=lambda x: x.lower() == "true",
         default=False,
         help="Whether to replace tier1a variables in cancer_panel_test table",
     )
@@ -846,10 +883,28 @@ def main():
     store_data(syn, master_table, label_data, table_type, cohort, logger, dry_run)
     if not dry_run:
         if replace_patient_tier1a or replace_sample_tier1a:
-            custom_fix_for_tier1a_variable(syn, master_table, logger, config, cohort, replace_patient_tier1a, replace_sample_tier1a, comment)
+            custom_fix_for_tier1a_variable(
+                syn,
+                master_table,
+                logger,
+                config,
+                cohort,
+                replace_patient_tier1a,
+                replace_sample_tier1a,
+                comment,
+            )
         if not replace_sample_tier1a:
             # replace cpt_seq_date separately if not replace other tier1a variables in cancer panel test table
-            custom_fix_for_cpt_seq_data(syn, master_table, logger, config, cohort, comment, replace_patient_tier1a, replace_sample_tier1a)
+            custom_fix_for_cpt_seq_data(
+                syn,
+                master_table,
+                logger,
+                config,
+                cohort,
+                comment,
+                replace_patient_tier1a,
+                replace_sample_tier1a,
+            )
         if table_type == "primary":
             table_id, condition = list(TABLE_INFO["redacted"])
             redacted_table_info = utilities.download_synapse_table(

--- a/scripts/table_updates/update_data_table.py
+++ b/scripts/table_updates/update_data_table.py
@@ -27,15 +27,8 @@ import numpy
 import pandas
 import synapseclient
 import utilities
-from synapseclient import (
-    Column,
-    Row,
-    RowSet,
-    Schema,
-    Table,
-    as_table_columns,
-    build_table,
-)
+from synapseclient import (Column, Row, RowSet, Schema, Table,
+                           as_table_columns, build_table)
 
 TABLES = {
     "production": {
@@ -661,7 +654,7 @@ def custom_fix_for_tier1a_variable(
     # master_table["form"] = master_table["form"].apply(lambda x: ", ".join(x))
 
     # load GENIE BPC elements mapping table
-    column_mapping_table = utilities.download_synapse_table(syn, "syn20945902")
+    column_mapping_table = utilities.download_synapse_table(syn, config["genie_bpc_elements_mapping"])
 
     if replace_patient_tier1a:
         logger.info("Replace patient tier1a variables in progress...")
@@ -749,7 +742,7 @@ def custom_fix_for_cpt_seq_data(
     #    master_table["form"] = master_table["form"].apply(lambda x: ", ".join(x))
 
     # load GENIE BPC elements mapping table
-    column_mapping_table = utilities.download_synapse_table(syn, "syn20945902")
+    column_mapping_table = utilities.download_synapse_table(syn, config["genie_bpc_elements_mapping"])
 
     # load main genie sample file
     genie_sample_dat = get_main_genie_clinical_file(

--- a/scripts/table_updates/update_data_table.py
+++ b/scripts/table_updates/update_data_table.py
@@ -27,8 +27,15 @@ import numpy
 import pandas
 import synapseclient
 import utilities
-from synapseclient import (Column, Row, RowSet, Schema, Table,
-                           as_table_columns, build_table)
+from synapseclient import (
+    Column,
+    Row,
+    RowSet,
+    Schema,
+    Table,
+    as_table_columns,
+    build_table,
+)
 
 TABLES = {
     "production": {
@@ -517,7 +524,7 @@ def update_tier1a(
         & (column_mapping_table["cohort"] == cohort),
     ]
     valid_col = subset_column_mapping_table.prissmm_element.tolist()
-    # import pdb; pdb.set_trace()
+
     if not all(item in valid_col for item in bpc_column_list):
         raise ValueError(
             f"Invalid bpc_column_list. Column names should be matching {valid_col}."
@@ -654,7 +661,9 @@ def custom_fix_for_tier1a_variable(
     # master_table["form"] = master_table["form"].apply(lambda x: ", ".join(x))
 
     # load GENIE BPC elements mapping table
-    column_mapping_table = utilities.download_synapse_table(syn, config["genie_bpc_elements_mapping"])
+    column_mapping_table = utilities.download_synapse_table(
+        syn, config["genie_bpc_elements_mapping"]
+    )
 
     if replace_patient_tier1a:
         logger.info("Replace patient tier1a variables in progress...")
@@ -742,7 +751,9 @@ def custom_fix_for_cpt_seq_data(
     #    master_table["form"] = master_table["form"].apply(lambda x: ", ".join(x))
 
     # load GENIE BPC elements mapping table
-    column_mapping_table = utilities.download_synapse_table(syn, config["genie_bpc_elements_mapping"])
+    column_mapping_table = utilities.download_synapse_table(
+        syn, config["genie_bpc_elements_mapping"]
+    )
 
     # load main genie sample file
     genie_sample_dat = get_main_genie_clinical_file(


### PR DESCRIPTION

# **Problem:**

Originally, we only support replacing BPC tier 1a variables with _DETAILED columns from main genie release file. 

# **Solution:**

Using the updated column mapping table, which includes the cohort and main_genie_release_version columns, extract the corresponding columns from the main GENIE dataset.

# **Testing:**

Unit tests have been updated. 