### PR TITLE
[GEN-1962] add yesno mapping to the mapping when grs is not used

### DIFF
--- a/scripts/uploads/merge_and_uncode_rca_uploads.R
+++ b/scripts/uploads/merge_and_uncode_rca_uploads.R
@@ -341,7 +341,7 @@ uncode_data <- function(df_coded, dd, grs, use_grs) {
     mappings <- merge_mappings(mappings_primary, mappings_secondary)
   } else {
     mappings_dd <- parse_mappings(strs = dd[[config$column_name$variable_mapping]], 
-                            labels = dd[[config$column_name$variable_name]])
+                                  labels = dd[[config$column_name$variable_name]])
     yesno_vars <- dd[config$column_name$variable_name][dd[config$column_name$field_type] == 'yesno']
     mappings_yesno <- setNames(lapply(yesno_vars, function(name) parse_mapping("0, No|1, Yes")), yesno_vars)
     mappings <- c(mappings_dd, mappings_yesno)

--- a/scripts/uploads/merge_and_uncode_rca_uploads.R
+++ b/scripts/uploads/merge_and_uncode_rca_uploads.R
@@ -340,8 +340,11 @@ uncode_data <- function(df_coded, dd, grs, use_grs) {
                             labels = dd[[config$column_name$variable_name]])
     mappings <- merge_mappings(mappings_primary, mappings_secondary)
   } else {
-    mappings <- parse_mappings(strs = dd[[config$column_name$variable_mapping]], 
+    mappings_dd <- parse_mappings(strs = dd[[config$column_name$variable_mapping]], 
                             labels = dd[[config$column_name$variable_name]])
+    yesno_vars <- dd[config$column_name$variable_name][dd[config$column_name$field_type] == 'yesno']
+    mappings_yesno <- setNames(lapply(yesno_vars, function(name) parse_mapping("0, No|1, Yes")), yesno_vars)
+    mappings <- c(mappings_dd, mappings_yesno)
   }
 
   mapping_complete <- data.frame(codes = names(config$mapping$complete),

--- a/scripts/uploads/tests/test_merge_and_uncode_rca_uploads.R
+++ b/scripts/uploads/tests/test_merge_and_uncode_rca_uploads.R
@@ -28,6 +28,11 @@ setup({
           data2 = "mock_data4_id"
         )
       )
+    ),
+    column_name = list(
+      variable_name = "variable_name",
+      field_type = "field_type",
+      variable_mapping = "variable_mapping"
     )
   )
 
@@ -83,4 +88,33 @@ test_that("get_prov_used returns correct prov when use_grs is TRUE", {
   result <- get_prov_used(cohort = "cohort1", use_grs = TRUE)
   print(result)
   expect_equal(result, c("mock_data1_id", "mock_data2_id", "mock_data3_id", "mock_data4_id", "mock_synid_dd", "mock_grs_id"))
+})
+
+test_that("uncode_data decodes codes correctly when use_grs is FALSE", {
+  # Mock input
+  input_data <- data.frame(
+    record_id = c(1, 2, 3),
+    yesno_field = c(0, 1, 1),
+    dropdown_radio_field = c(1, 2, 3)
+  )
+  
+  dd <- data.frame(
+    variable_name = c("record_id", "yesno_field", "dropdown_radio_field"),
+    field_type = c("text", "yesno", "dropdown"),
+    variable_mapping = c(NA,NA,"1,foo|2,bar|3,test")
+  )
+  
+  # Expected output after decoding
+  expected_output <- data.frame(
+    record_id = c(1, 2, 3),
+    yesno_field = c("No", "Yes", "Yes"),
+    dropdown_radio_field = c("foo", "bar", "test"),
+    stringsAsFactors = FALSE
+  )
+  
+  # Run function
+  result <- uncode_data(input_data, dd, grs=NULL, use_grs=FALSE)
+  
+  # Test
+  expect_equal(result, expected_output)
 })


### PR DESCRIPTION
# **Problem:**

When the grs toggle is set to no, the yesno variables are not included in the mappings object, which causes those variables do not map to any text labels.

See detailed comments in https://sagebionetworks.jira.com/browse/GEN-1961

# **Solution:**

Added the list of yesno variables to the mappings object with 0=No, 1=Yes as mapping

