### PR TITLE
[GEN-1837] Add age max filter

### DIFF
--- a/scripts/case_selection/perform_case_selection.R
+++ b/scripts/case_selection/perform_case_selection.R
@@ -230,7 +230,7 @@ create_eligibility_matrix <- function(data,
   # <= age max at sequencing
   if (!is.infinite(age_max)) {
     mat <- mat %>%
-      mutate(FLAG_AGE_MAX = is.double(AGE_AT_SEQ_REPORT_DAYS) & AGE_AT_SEQ_REPORT_DAYS <= age_max)
+      mutate(FLAG_AGE_MAX = as.numeric(AGE_AT_SEQ_REPORT_DAYS) <= age_max)
   }else{
     mat <- mat %>%
       mutate(FLAG_AGE_MAX = TRUE)

--- a/scripts/case_selection/perform_case_selection.R
+++ b/scripts/case_selection/perform_case_selection.R
@@ -204,6 +204,7 @@ create_eligibility_matrix <- function(data,
                                       allowed_codes, 
                                       seq_min, 
                                       seq_max,
+                                      age_max,
                                       exclude_patient_id = c(),
                                       exclude_sample_id = c()) {
   
@@ -213,7 +214,10 @@ create_eligibility_matrix <- function(data,
     mutate(FLAG_ALLOWED_CODE = is.element(ONCOTREE_CODE, allowed_codes)) %>%   
     
     # >=18 years old at sequencing
-    mutate(FLAG_ADULT = AGE_AT_SEQ_REPORT_DAYS != '<6570') %>%            
+    mutate(FLAG_ADULT = AGE_AT_SEQ_REPORT_DAYS != '<6570') %>%       
+    
+    # <= age max at sequencing
+    mutate(FLAG_AGE_MAX = AGE_AT_SEQ_REPORT_DAYS <= age_max) %>%
     
     # sequenced within specified time range
     mutate(FLAG_SEQ_DATE = my(SEQ_DATE) >= my(seq_min) & my(SEQ_DATE) <= my(seq_max)) %>%
@@ -237,6 +241,7 @@ create_eligibility_matrix <- function(data,
            SEQ_ALIVE_INT,
            FLAG_ALLOWED_CODE, 
            FLAG_ADULT, 
+           FLAG_AGE_MAX,
            FLAG_SEQ_DATE, 
            SEQ_ALIVE_YR,
            FLAG_NOT_EXCLUDED)         
@@ -335,6 +340,7 @@ if (debug) {
 exclude_patient_id <- c()
 exclude_sample_id <- c()
 seq_dates <- get_seq_dates(config, phase, cohort, site)
+age_max_days <- get_age_max_days(config, phase, cohort)
 
 flag_prev_release <- (config$release$cohort[[cohort]]$patient_level_dataset != "NA")
 if (phase == 2 && flag_prev_release) {
@@ -350,6 +356,7 @@ eligibility_matrix <- create_eligibility_matrix(data = eligibility_data,
                                                 allowed_codes = config$phase[[phase]]$cohort[[cohort]]$oncotree$allowed_codes, 
                                                 seq_min = seq_dates$seq_min, 
                                                 seq_max = seq_dates$seq_max,
+                                                age_max = age_max_days,
                                                 exclude_patient_id = exclude_patient_id,
                                                 exclude_sample_id = exclude_sample_id)
 

--- a/scripts/case_selection/perform_case_selection.R
+++ b/scripts/case_selection/perform_case_selection.R
@@ -216,9 +216,6 @@ create_eligibility_matrix <- function(data,
     # >=18 years old at sequencing
     mutate(FLAG_ADULT = AGE_AT_SEQ_REPORT_DAYS != '<6570') %>%       
     
-    # <= age max at sequencing
-    mutate(FLAG_AGE_MAX = AGE_AT_SEQ_REPORT_DAYS <= age_max) %>%
-    
     # sequenced within specified time range
     mutate(FLAG_SEQ_DATE = my(SEQ_DATE) >= my(seq_min) & my(SEQ_DATE) <= my(seq_max)) %>%
     
@@ -228,8 +225,18 @@ create_eligibility_matrix <- function(data,
     mutate(SEQ_ALIVE_INT = !is_double(INT_CONTACT) | INT_CONTACT >= AGE_AT_SEQ_REPORT_DAYS) %>%
     
     # patient not explicitly excluded
-    mutate(FLAG_NOT_EXCLUDED = !is.element(PATIENT_ID, exclude_patient_id) & !is.element(SAMPLE_ID, exclude_sample_id))  %>% 
-
+    mutate(FLAG_NOT_EXCLUDED = !is.element(PATIENT_ID, exclude_patient_id) & !is.element(SAMPLE_ID, exclude_sample_id))
+  
+  # <= age max at sequencing
+  if (!is.infinite(age_max)) {
+    mat <- mat %>%
+      mutate(FLAG_AGE_MAX = is.double(AGE_AT_SEQ_REPORT_DAYS) & AGE_AT_SEQ_REPORT_DAYS <= age_max)
+  }else{
+    mat <- mat %>%
+      mutate(FLAG_AGE_MAX = TRUE)
+  }
+    
+  mat <- mat %>% 
     select(PATIENT_ID, 
            SAMPLE_ID, 
            ONCOTREE_CODE, 

--- a/scripts/case_selection/perform_case_selection.Rmd
+++ b/scripts/case_selection/perform_case_selection.Rmd
@@ -92,7 +92,7 @@ Eligible samples are defined with following criteria:
     * Allowed codes: `r paste0(config$phase[[phase]]$cohort[[cohort]]$oncotree$allowed_codes, collapse = ", ")`
 2. Patient contributing sample was within the allowable age range at the time of sequencing
     * Minimum age: `r config$default$global$age_min`
-    * Maximum age: `r if (!is.null(config$phase[[1]]$cohort[[cohort]]$age_max)) config$phase[[1]]$cohort$BrCa$age_max else config$default$global$age_max`
+    * Maximum age: `r get_age_max(config, phase, cohort)`
 3. Sample was sequenced between allowed date range
     * Minimum sequencing date: `r config$phase[[phase]]$cohort[[cohort]]$date$seq_min`
     * Maximum sequencing date: `r config$phase[[phase]]$cohort[[cohort]]$date$seq_max`

--- a/scripts/case_selection/shared_fxns.R
+++ b/scripts/case_selection/shared_fxns.R
@@ -26,16 +26,20 @@ get_default_site <- function(config, site, key) {
   return(config$default$site[[site]][[key]])
 }
 
-get_custom <- function(config, phase, cohort, site, key) {
+get_custom_site <- function(config, phase, cohort, site, key) {
   return(config$phase[[phase]]$cohort[[cohort]]$site[[site]][[key]])
 }
 
+get_custom_cohort <- function(config, phase, cohort, key) {
+  return(config$phase[[phase]]$cohort[[cohort]][[key]])
+}
+
 get_production <- function(config, phase, cohort, site) {
-  get_custom(config = config, phase = phase, cohort = cohort, site = site, key = "production")
+  get_custom_site(config = config, phase = phase, cohort = cohort, site = site, key = "production")
 }
 
 get_adjusted <- function(config, phase, cohort, site) {
-  get_custom(config = config, phase = phase, cohort = cohort, site = site, key = "adjusted")
+  get_custom_site(config = config, phase = phase, cohort = cohort, site = site, key = "adjusted")
 }
 
 get_pressure <- function(config, phase, cohort, site) {
@@ -62,7 +66,7 @@ get_sdv_or_irr_value <- function(config, phase, cohort, site, key = c("sdv", "ir
   }
   
   # custom
-  val_custom <- get_custom(config, phase, cohort, site, key)
+  val_custom <- get_custom_site(config, phase, cohort, site, key)
   if (!is.null(val_custom) && !is.na(val_custom)) {
     if (val_custom < 1) {
       return(round(val_custom * (n_prod)))
@@ -96,6 +100,14 @@ get_sdv <- function(config, phase, cohort, site) {
 
 get_irr <- function(config, phase, cohort, site) {
   return(get_sdv_or_irr_value(config, phase, cohort, site, "irr"))
+}
+
+get_age_max <- function(config, phase, cohort) {
+  cohort_age_max <- get_custom_cohort(config, phase, cohort, "age_max")
+  if(!is.null(cohort_age_max)){
+    return(cohort_age_max)
+  }
+  return(get_default_global(config, "age_max"))
 }
 
 now <- function(timeOnly = F, tz = "US/Pacific") {

--- a/scripts/case_selection/shared_fxns.R
+++ b/scripts/case_selection/shared_fxns.R
@@ -103,11 +103,16 @@ get_irr <- function(config, phase, cohort, site) {
 }
 
 get_age_max <- function(config, phase, cohort) {
+  age_max <- get_default_global(config, "age_max")
   cohort_age_max <- get_custom_cohort(config, phase, cohort, "age_max")
   if(!is.null(cohort_age_max)){
-    return(cohort_age_max)
+    age_max <- cohort_age_max
   }
-  return(get_default_global(config, "age_max"))
+  return(as.numeric(age_max))
+}
+
+get_age_max_days <- function(config, phase, cohort) {
+  return(get_age_max(config, phase, cohort)*365)
 }
 
 now <- function(timeOnly = F, tz = "US/Pacific") {


### PR DESCRIPTION
# **Problem:**
We would like to restrict the age upper limit during case selection process. The age_max flag is already in the current configuration file. Global setting is Inf. 

# **Solution:**

- Add related helper functions to get age_max in years and days
- Add the age_max filter to the create_eligibility_matrix function using age_max in days
- update the rmarkdown using age_max in years

# **Testing:**
Currently there is no testing. Also the filter logic needs to be refined 