### PR TITLE
[GEN-1783] Update perform_case_selection.R age max logic

### DIFF
--- a/scripts/case_selection/config.yaml
+++ b/scripts/case_selection/config.yaml
@@ -603,7 +603,7 @@ phase:
         date: 
           seq_min: Apr-2012
           seq_max: Oct-2022
-        age_max: 85
+        age_max: 86
         oncotree:
           root: EGC
           allowed_codes: 

--- a/scripts/case_selection/perform_case_selection.R
+++ b/scripts/case_selection/perform_case_selection.R
@@ -227,10 +227,10 @@ create_eligibility_matrix <- function(data,
     # patient not explicitly excluded
     mutate(FLAG_NOT_EXCLUDED = !is.element(PATIENT_ID, exclude_patient_id) & !is.element(SAMPLE_ID, exclude_sample_id))
   
-  # <= age max at sequencing
+  # < age max at sequencing
   if (!is.infinite(age_max)) {
     mat <- mat %>%
-      mutate(FLAG_AGE_MAX = as.numeric(AGE_AT_SEQ_REPORT_DAYS) <= age_max)
+      mutate(FLAG_AGE_MAX = as.numeric(AGE_AT_SEQ_REPORT_DAYS) < age_max)
   }else{
     mat <- mat %>%
       mutate(FLAG_AGE_MAX = TRUE)


### PR DESCRIPTION
# **Problem:**

In order for us to set an age max of 85 years of age (e.g. 85.999 years of age patients is eligible for in cohort select), we need to update the age max logic to be < and not <=. We will also have to make it so the age_max is +1 of what the colloquial term for age_max is. 

# **Solution:**

Update this section: `AGE_AT_SEQ_REPORT_DAYS <= age_max` to reflect `AGE_AT_SEQ_REPORT_DAYS < age_max` 

# **Testing:**

No testing done.