### PR TITLE
[GEN-1996] update table schema

### DIFF
--- a/scripts/table_updates/README.md
+++ b/scripts/table_updates/README.md
@@ -22,9 +22,6 @@ Please make sure you have the [.synapseConfig file](https://help.synapse.org/doc
 Make sure you have Python 3.8 and conda installed.
 
 ### Install the required packages
-```
-pip install 'synapseclient[pandas] == 2.7.2'
-```
 
 > [!NOTE]  
 > Due to this tool using an older version of the python client, until there is bandwidth to update
@@ -62,10 +59,6 @@ The `update_data_table.py` script is used to update the BPC internal tables.
 Make sure you have Python 3.9+ and conda installed.
 
 ### Install the required packages
-
-```
-pip install -r requirements.txt
-```
 
 ```
 conda create -n genie-table-update python=3.10

--- a/scripts/table_updates/README.md
+++ b/scripts/table_updates/README.md
@@ -3,25 +3,28 @@ BPC Table Update
 [![automated](https://img.shields.io/docker/cloud/automated/sagebionetworks/genie-bpc-pipeline-table-updates)](https://hub.docker.com/r/sagebionetworks/genie-bpc-pipeline-table-updates)
 ![status](https://img.shields.io/docker/cloud/build/sagebionetworks/genie-bpc-pipeline-table-updates)
 
-Installation and Setup
-----------------------
-### Python version
-Make sure you have Python 3.8 installed.
 
+This folder contains multiple scripts to update the tables required for the BPC pipeline.  Note there are two separate update scripts right now
+that may require different synapseclient versions. We encourage using different conda environments for each script.
 
-### Install the required packages
-
-```
-pip install -r requirements.txt
-```
-
-### Synapse Credential
-Please make sure you have the [.synapseConfig file](https://help.synapse.org/docs/Client-Configuration.1985446156.html)
-
-### Service catalog instance
+# Service catalog instance
 Use a t3.2xlarge ec2 instance for large memory requirement.
 
-Putting it all together.
+# Synapse Credential
+Please make sure you have the [.synapseConfig file](https://help.synapse.org/docs/Client-Configuration.1985446156.html)
+
+
+# Update data element catalog + table schema
+
+## Installation and Setup
+
+### Python version
+Make sure you have Python 3.8 and conda installed.
+
+### Install the required packages
+```
+pip install 'synapseclient[pandas] == 2.7.2'
+```
 
 > [!NOTE]  
 > Due to this tool using an older version of the python client, until there is bandwidth to update
@@ -31,17 +34,16 @@ Putting it all together.
 > AttributeError: 'dict' object has no attribute 'endswith'
 > ```
 
-
 ```
 # Make sure you have anaconda installed
-conda create -n genie-table-update python=3.8
-conda activate genie-table-update
-pip install -r requirements.txt
+conda create -n genie-table-update-precursor python=3.8
+conda activate genie-table-update-precursor
+pip install 'synapseclient[pandas] == 2.7.2'
 ```
 
-Usage
------
-### Prepare the Synapse tables to be updated
+### Usage
+
+Prepare the Synapse tables to be updated
 > **_NOTE:_** ONLY need to be executed when there is a new version of PRISSMM data dictionary
 
 ##### Step 1. Update the Data Catalog
@@ -49,8 +51,34 @@ Usage
 ##### Step 2. Update the table schema
     python update_table_schema.py
 
-### Update the Synapse Tables with data
+
+# Update Data Table
+
+The `update_data_table.py` script is used to update the BPC internal tables. 
+
+## Installation and Setup
+
+### Python version
+Make sure you have Python 3.9+ and conda installed.
+
+### Install the required packages
+
+```
+pip install -r requirements.txt
+```
+
+```
+conda create -n genie-table-update python=3.10
+conda activate genie-table-update
+pip install -r requirements.txt
+```
+
+### Usage
+Update the Synapse Tables with data
+
 #### Primary Case Tables
     python update_data_table.py -m [version_comment] primary
 #### IRR Case Tables
     python update_data_table.py -m [version_comment] irr
+
+This is to run the script manually, there is a nextflow workflow associated with this script.

--- a/scripts/table_updates/README.md
+++ b/scripts/table_updates/README.md
@@ -44,10 +44,16 @@ Prepare the Synapse tables to be updated
 > **_NOTE:_** ONLY need to be executed when there is a new version of PRISSMM data dictionary
 
 ##### Step 1. Update the Data Catalog
-    python update_data_element_catalog.py -v [prissmm_version_number]
-##### Step 2. Update the table schema
-    python update_table_schema.py
 
+```
+python update_data_element_catalog.py -v [prissmm_version_number]
+```
+
+##### Step 2. Update the table schema
+
+```
+python update_table_schema.py
+```
 
 # Update Data Table
 

--- a/scripts/table_updates/README.md
+++ b/scripts/table_updates/README.md
@@ -6,11 +6,14 @@ BPC Table Update
 Installation and Setup
 ----------------------
 ### Python version
-Make sure you have Python 3.8 installed
+Make sure you have Python 3.8 installed.
 
 
 ### Install the required packages
-    (sudo) pip install -r requirements.txt
+
+```
+pip install -r requirements.txt
+```
 
 ### Synapse Credential
 Please make sure you have the [.synapseConfig file](https://help.synapse.org/docs/Client-Configuration.1985446156.html)
@@ -19,6 +22,15 @@ Please make sure you have the [.synapseConfig file](https://help.synapse.org/doc
 Use a t3.2xlarge ec2 instance for large memory requirement.
 
 Putting it all together.
+
+> [!NOTE]  
+> Due to this tool using an older version of the python client, until there is bandwidth to update
+> please do `rm -rf ~/.synapseCache/*` to clear the synapse cache to avoid this error
+> ```
+> if cached_time.endswith(".000Z"):
+> AttributeError: 'dict' object has no attribute 'endswith'
+> ```
+
 
 ```
 # Make sure you have anaconda installed

--- a/scripts/table_updates/update_data_element_catalog.py
+++ b/scripts/table_updates/update_data_element_catalog.py
@@ -114,11 +114,12 @@ def _update_by_data_dictionary(data_dictionary, data_element_catalog, logger):
     vars_with_choices[['choices_num','max_len','choices_key']] = vars_with_choices['choices'].apply(_get_choices_info)
     # check for variables with choices that the max_len(choices) > synColSize
     # TODO: yesno can be changed to choices 
-    vars_to_update = vars_with_choices.query('max_len > synColSize')
+    vars_to_update = vars_with_choices.query('(max_len > synColSize) or synColSize.isna()')
     vars_to_update['synColSize'] = vars_to_update['max_len']
     # check for number of checkbox variables > numCols
+    # check for null values
     vars_checkbox = vars_with_choices[vars_with_choices['type']=='checkbox']
-    vars_checkbox_update = vars_checkbox.query('choices_num > numCols')
+    vars_checkbox_update = vars_checkbox.query('(choices_num > numCols) or numCols.isna()')
     vars_checkbox_update['numCols'] = vars_checkbox_update['choices_num']
     vars_checkbox_update['colLabels'] = vars_checkbox_update['choices_key']
     # combined variables for update

--- a/scripts/table_updates/update_table_schema.py
+++ b/scripts/table_updates/update_table_schema.py
@@ -27,7 +27,7 @@ def create_synapse_column(name, col_type, max_size):
         new_column = Column(name=name,
                             columnType=col_type)
     else:
-        max_size = 100 if pandas.isna(max_size) else int(max_size)
+        max_size = 500 if pandas.isna(max_size) else int(max_size)
         new_column = Column(name=name,
                             columnType=col_type, 
                             maximumSize=max_size)

--- a/scripts/table_updates/update_table_schema.py
+++ b/scripts/table_updates/update_table_schema.py
@@ -27,9 +27,10 @@ def create_synapse_column(name, col_type, max_size):
         new_column = Column(name=name,
                             columnType=col_type)
     else:
+        max_size = 100 if pandas.isna(max_size) else int(max_size)
         new_column = Column(name=name,
                             columnType=col_type, 
-                            maximumSize=int(max_size))
+                            maximumSize=max_size)
     return new_column
 
 def _expand_checkbox_vars(row):


### PR DESCRIPTION
# **Problem:**
The ovarian cohort had a new data dictionary which requires us to run update_table_schema.py code to make sure new columns were added.

While running this code, a failure occurred
```
Traceback (most recent call last):
  File "/Users/tyu/sage/genie-bpc-pipeline/scripts/table_updates/update_table_schema.py", line 203, in <module>
    main()
  File "/Users/tyu/sage/genie-bpc-pipeline/scripts/table_updates/update_table_schema.py", line 200, in main
    update_table_schema(syn,logger,dry_run)
  File "/Users/tyu/sage/genie-bpc-pipeline/scripts/table_updates/update_table_schema.py", line 167, in update_table_schema
    _update_table_schema(syn, form, curated_data_element, logger, dry_run)
  File "/Users/tyu/sage/genie-bpc-pipeline/scripts/table_updates/update_table_schema.py", line 82, in _update_table_schema
    non_check_new_cols = list(non_check_to_add_df.apply(lambda x: create_synapse_column(x['variable'],x['synColType'],x['synColSize']),axis=1))
  File "/Users/tyu/anaconda3/envs/synapse/lib/python3.10/site-packages/pandas/core/frame.py", line 10034, in apply
    return op.apply().__finalize__(self, method="apply")
  File "/Users/tyu/anaconda3/envs/synapse/lib/python3.10/site-packages/pandas/core/apply.py", line 837, in apply
    return self.apply_standard()
  File "/Users/tyu/anaconda3/envs/synapse/lib/python3.10/site-packages/pandas/core/apply.py", line 965, in apply_standard
    results, res_index = self.apply_series_generator()
  File "/Users/tyu/anaconda3/envs/synapse/lib/python3.10/site-packages/pandas/core/apply.py", line 981, in apply_series_generator
    results[i] = self.func(v, *self.args, **self.kwargs)
  File "/Users/tyu/sage/genie-bpc-pipeline/scripts/table_updates/update_table_schema.py", line 82, in <lambda>
    non_check_new_cols = list(non_check_to_add_df.apply(lambda x: create_synapse_column(x['variable'],x['synColType'],x['synColSize']),axis=1))
  File "/Users/tyu/sage/genie-bpc-pipeline/scripts/table_updates/update_table_schema.py", line 32, in create_synapse_column
    maximumSize=int(max_size))
ValueError: cannot convert float NaN to integer
```

# **Solution:**
hacky workaround to auto fill in string of length 100.  This could fail for any column that has longer string length than 100 for a particular row

# **Testing:**
Ran the code - no tests.