### PR TITLE
[GEN-1951] Update config.json

### DIFF
--- a/scripts/table_updates/config.json
+++ b/scripts/table_updates/config.json
@@ -26,7 +26,7 @@
         "cancer_panel_test_tier1a_replacement_mapping_table": "syn65880475"
     },
     "genie_bpc_elements_mapping": "syn20945902",
-    "main_genie_release_version": "16.2-consortium",
+    "main_genie_release_version": "14.6-consortium",
     "main_genie_data_release_files": "syn16804261",
     "main_genie_sample_mapping_table": "syn7434273",
     "patient_tier1a_column_list_to_be_replaced": [


### PR DESCRIPTION
Updating to use the 14.6-consortium main GENIE release as the source for replacing NAACCR ethnicity, race, and sex fields, as well as the cpt_sample_type and cpt_seq_date fields, during the processing of Round 3 of the RENAL cohort. The 14.6-consortium release serves as the official data lock for the RENAL cohort, as outlined here. [table](https://docs.google.com/spreadsheets/d/1P9-sT8ZvQ_Bvw8bEQOt9CaRo4rQIKLKE1yrWP-EHBq0/edit?gid=0#gid=0).