### PR TITLE
[GEN-2037] Update config.json

### DIFF
--- a/scripts/table_updates/config.json
+++ b/scripts/table_updates/config.json
@@ -26,7 +26,7 @@
         "cancer_panel_test_tier1a_replacement_mapping_table": "syn65880475"
     },
     "genie_bpc_elements_mapping": "syn20945902",
-    "main_genie_release_version": "9.5-consortium",
+    "main_genie_release_version": "11.3-consortium",
     "main_genie_data_release_files": "syn16804261",
     "main_genie_sample_mapping_table": "syn7434273",
     "patient_tier1a_column_list_to_be_replaced": [


### PR DESCRIPTION
Updating to use 11.3-consortium per the data lock for the Bladder cohort