### PR TITLE
[GEN-1773] Implement `params.entry` due to Nextflow's workflow entry option deprecation

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,11 +217,21 @@ This workflow takes care of transferring files to and from Synapse. Hence, it re
 1. Generate a personal access token (PAT) on Synapse using [this dashboard](https://www.synapse.org/#!PersonalAccessTokens:). Make sure to enable the `view`, `download`, and `modify` scopes since this workflow both downloads and uploads to Synapse.
 2. Create a secret called `SYNAPSE_AUTH_TOKEN` containing a Synapse personal access token using the [Nextflow CLI](https://nextflow.io/docs/latest/secrets.html)
 
-### Commands
+### Running the pipeline
 
 You can visit [parameters](https://github.com/Sage-Bionetworks/genie-bpc-pipeline/blob/develop/main.nf#L2-L11) to see the list of currently available parameters/flags and their default values if you don't specify any.
 
-### Running nextflow using an EC2
+#### Running with docker locally
+
+Add `-with-docker <docker_image_name>` to every nextflow command to invoke docker in general to be used. See [docker-containers](https://www.nextflow.io/docs/latest/docker.html#docker-containers) for more details.
+
+Note that all the docker parameters have set default docker containers based on the **profile** you select. If you want to use a different default from what is available in the profiles, you must:
+
+1. Docker pull the container(s) you want to use in your local / ec2 instance
+2. Specify the parameter(s) in your command call below to be the container(s) you pulled
+
+
+#### Running nextflow locally or using an EC2
 
 1. For an ec2 instance with Linux and docker, see here for installing Java 11: [How do I install a software package from the Extras Library on an EC2 instance running Amazon Linux 2?](https://aws.amazon.com/premiumsupport/knowledge-center/ec2-install-extras-library-software/)
 
@@ -233,11 +243,14 @@ You can visit [parameters](https://github.com/Sage-Bionetworks/genie-bpc-pipelin
 nextflow secrets set SYNAPSE_AUTH_TOKEN “INSERT YOUR SYNAPSE TOKEN HERE”
 ```
 
-4. Run the pipeline with the default parameter settings
+#### *NEW* parameter `entry`
+Starting in `0.0.5`, we need to use a new parameter `entry` to specify what workflow we will be running via `--entry <entry_workflow_name>`.
 
-```bash
-nextflow main.nf
-```
+This is also available via the `profile` base nextflow parameter by using `-profile <profile_name>`. See available ones in `nextflow.config`. The profiles are mainly for Seqera platform for ease of just selecting the profile without having to type out the entry workflow name.
+
+#### Commands
+
+**BPC Pipeline**
 
 If you want to pass values to the parameter settings, you can use the help flag to see what parameters you can set:
 
@@ -245,16 +258,64 @@ If you want to pass values to the parameter settings, you can use the help flag 
 nextflow main.nf --help
 ```
 
-If you want to run the pipeline in production mode with the default parameter settings:
+Run the bpc processing pipeline with the default parameter settings
 
 ```bash
-nextflow main.nf --production
+nextflow main.nf \
+	--profile bpc_pipeline \
+	-with-docker sagebionetworks/genie-bpc-pipeline-table-updates:latest \
+	--references_docker sagebionetworks/genie-bpc-pipeline-references \
+	--uploads_docker sagebionetworks/genie-bpc-pipeline-uploads \
+	--table_updates_docker sagebionetworks/genie-bpc-pipeline-table-updates
+```
+
+Run the bpc processing pipeline for a specific pipeline step: table updates by specifying the `--step` flag like:
+
+```bash
+nextflow main.nf \
+	--step update_data_table \
+	--table_updates_docker sagebionetworks/genie-bpc-pipeline-table-updates \
+	--entry bpc_pipeline \
+	-with-docker sagebionetworks/genie-bpc-pipeline-table-updates:latest \
+	--table_updates_docker sagebionetworks/genie-bpc-pipeline-table-updates
+```
+
+If you want to run the pipeline in production mode with the default parameter settings, add a production flag:
+
+```bash
+nextflow main.nf <rest_of_command> --production
+```
+
+**Case Selection Workflow**
+
+If you want to pass values to the parameter settings, you can use the help flag to see what parameters you can set:
+
+```bash
+nextflow subworkflows/case_selection_workflow.nf  --help
+```
+
+To run case selection for CRC cohort:
+
+```bash
+nextflow run subworkflows/case_selection_workflow.nf 
+  --cohort CRC 
+  --entry case_selection
+  -with-docker sagebionetworks/genie-bpc-pipeline-case-selection:latest
+```
+
+To run export BPC cases:
+
+```bash
+nextflow run subworkflows/case_selection_workflow.nf 
+  --cohort CRC 
+  --entry export_bpc_cases
+  -with-docker sagebionetworks/genie-bpc-pipeline-case-selection:latest
 ```
 
 Note: you can also chose what version of nextflow to run with using:
 
 ```bash
-NXF_VER=<nextflow_version> nextflow main.nf
+NXF_VER=<nextflow_version> nextflow main.nf <rest_of_command>
 ```
 
 ## Citations

--- a/lib/NfcoreSchema.groovy
+++ b/lib/NfcoreSchema.groovy
@@ -60,7 +60,6 @@ class NfcoreSchema {
             'dump-channels',
             'dump-hashes',
             'E',
-            'entry',
             'latest',
             'lib',
             'main-script',

--- a/main.nf
+++ b/main.nf
@@ -44,6 +44,15 @@ if (params.help){
 // Validate input parameters
 NfcoreSchema.validateParameters(workflow, params, log)
 
+// entry validation
+valid_entry_points = ['bpc_pipeline', 'clinical_release']
+if (!params.entry) {
+    error "Entry point must be specified using --entry. Select one of: ${valid_entry_points.join(', ')}"
+}
+if (!valid_entry_points.contains(params.entry)) {
+    error "Invalid entry point: '${params.entry}'. Valid options are: ${valid_entry_points.join(', ')}"
+}
+
 // Check mandatory parameters
 if (params.cohort == null) { exit 1, 'cohort parameter not specified!' }
 if (params.comment == null) { exit 1, 'comment parameter not specified!' }
@@ -92,94 +101,100 @@ include { run_clinical_release } from './modules/run_clinical_release'
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 */
 
-workflow BPC_PIPELINE {
-   ch_cohort = Channel.value(params.cohort)
-   ch_comment = Channel.value(params.comment)
+workflow {
+    if (params.entry == "bpc_pipeline"){
+        ch_cohort = Channel.value(params.cohort)
+        ch_comment = Channel.value(params.comment)
    
-   if (params.step == "update_potential_phi_fields_table") {
-    update_potential_phi_fields_table(ch_comment, params.production)
-    // validate_data.out.view()
-   } else if (params.step == "merge_and_uncode_rca_uploads"){
-    merge_and_uncode_rca_uploads(
-        "default", 
-        ch_cohort, 
-        ch_comment, 
-        params.production, 
-        params.use_grs
-    )
-   } else if (params.step == "update_data_table") {
-    update_data_table(
-        "default", 
-        ch_cohort, 
-        ch_comment, 
-        params.production,
-        params.replace_patient_tier1a,
-        params.replace_sample_tier1a
-    )
-   } else if (params.step == "genie_bpc_pipeline"){
-    update_potential_phi_fields_table(ch_comment, params.production)
+        if (params.step == "update_potential_phi_fields_table") {
+            update_potential_phi_fields_table(ch_comment, params.production)
+            // validate_data.out.view()
+        } else if (params.step == "merge_and_uncode_rca_uploads"){
+            merge_and_uncode_rca_uploads(
+                "default", 
+                ch_cohort, 
+                ch_comment, 
+                params.production, 
+                params.use_grs
+            )
+        } else if (params.step == "update_data_table") {
+            update_data_table(
+                "default", 
+                ch_cohort, 
+                ch_comment, 
+                params.production,
+                params.replace_patient_tier1a,
+                params.replace_sample_tier1a
+            )
+        } else if (params.step == "genie_bpc_pipeline"){
+            update_potential_phi_fields_table(ch_comment, params.production)
 
-    run_quac_upload_report_error(
-        update_potential_phi_fields_table.out, 
-        ch_cohort
-    )
+            run_quac_upload_report_error(
+                update_potential_phi_fields_table.out, 
+                ch_cohort
+            )
 
-    run_quac_upload_report_warning(
-        run_quac_upload_report_error.out, 
-        ch_cohort, 
-        params.production
-    )
+            run_quac_upload_report_warning(
+                run_quac_upload_report_error.out, 
+                ch_cohort, 
+                params.production
+            )
 
-    merge_and_uncode_rca_uploads(
-        run_quac_upload_report_warning.out, 
-        ch_cohort,
-        ch_comment, 
-        params.production, 
-        params.use_grs
-    )
-    // remove_patients_from_merged(merge_and_uncode_rca_uploads.out, ch_cohort, params.production)
-    update_data_table(
-        merge_and_uncode_rca_uploads.out, 
-        ch_cohort, 
-        ch_comment, 
-        params.production,
-        params.replace_patient_tier1a,
-        params.replace_sample_tier1a
-    )
+            merge_and_uncode_rca_uploads(
+                run_quac_upload_report_warning.out, 
+                ch_cohort,
+                ch_comment, 
+                params.production, 
+                params.use_grs
+            )
+            // remove_patients_from_merged(merge_and_uncode_rca_uploads.out, ch_cohort, params.production)
+            update_data_table(
+                merge_and_uncode_rca_uploads.out, 
+                ch_cohort, 
+                ch_comment, 
+                params.production,
+                params.replace_patient_tier1a,
+                params.replace_sample_tier1a
+            )
 
-    update_date_tracking_table(
-        update_data_table.out, 
-        ch_cohort, 
-        ch_comment, 
-        params.production
-    )
+            update_date_tracking_table(
+                update_data_table.out, 
+                ch_cohort, 
+                ch_comment, 
+                params.production
+            )
 
-    run_quac_table_report(
-        update_date_tracking_table.out, 
-        ch_cohort, 
-        params.production
-    )
+            run_quac_table_report(
+                update_date_tracking_table.out, 
+                ch_cohort, 
+                params.production
+            )
 
-    run_quac_comparison_report(
-        run_quac_table_report.out, 
-        ch_cohort, 
-        params.production
-    )
+            run_quac_comparison_report(
+                run_quac_table_report.out, 
+                ch_cohort, 
+                params.production
+            )
 
-    create_masking_report(
-        run_quac_comparison_report.out, 
-        ch_cohort, 
-        params.production
-    )
+            create_masking_report(
+                run_quac_comparison_report.out, 
+                ch_cohort, 
+                params.production
+            )
 
-    update_case_count_table(
-        create_masking_report.out, 
-        ch_comment, 
-        params.production
-    )
-   } else {
-    exit 1, 'step not supported'
-   }
+            update_case_count_table(
+                create_masking_report.out, 
+                ch_comment, 
+                params.production
+            )
+        } else {
+            exit 1, 'step not supported'
+        }
+    } else if (params.entry == "clinical_release"){
+        run_clinical_release('', params.cohort, params.production)
+    } else {
+        error "Invalid entry point: '${params.entry}'. Valid options are: '${valid_entry_points.join(', ')}'"
+    }
 }
 
 /*
@@ -187,7 +202,3 @@ workflow BPC_PIPELINE {
     THE END
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 */
-
-workflow CLINICAL_RELEASE {
-    run_clinical_release('', params.cohort, params.production)
-}

--- a/nextflow.config
+++ b/nextflow.config
@@ -57,4 +57,10 @@ profiles {
 			table_updates_docker = "sagebionetworks/genie-bpc-pipeline-table-updates"
 		}
 	}
+	bpc_pipeline {
+		params.entry = "bpc_pipeline"
+	}
+	clinical_release {
+		params.entry = "clinical_release"
+	}
 }

--- a/subworkflows/case_selection_workflow.nf
+++ b/subworkflows/case_selection_workflow.nf
@@ -13,19 +13,30 @@ params.bpc_output = "syn62147862"
 params.release = "17.2-consortium"
 export_phase = "phase " + params.phase
 
+// entry validation
+valid_entry_points = ['export_bpc_cases', 'case_selection']
+if (!params.entry) {
+    error "Entry point must be specified using --entry. Select one of: ${valid_entry_points.join(', ')}"
+}
+if (!valid_entry_points.contains(params.entry)) {
+    error "Invalid entry point: '${params.entry}'. Valid options are: ${valid_entry_points.join(', ')}"
+}
+
 // import modules
 include { run_workflow_case_selection } from '../modules/run_workflow_case_selection'
 include { run_export_bpc_selected_cases } from '../modules/run_export_bpc_selected_cases'
 
-workflow export_bpc_cases {
-    // run_workflow_case_selection(params.phase, params.cohort, params.center, params.production)
-    run_export_bpc_selected_cases(params.bpc_input, params.bpc_output, export_phase, params.cohort, params.center, params.release)
-}
 
-
-workflow case_selection {
-    run_workflow_case_selection(params.phase, params.cohort, params.center, params.release, params.production)
-    // run_export_bpc_selected_cases(params.bpc_input, params.bpc_output, params.phase, params.cohort, params.center)
+workflow {
+    if (params.entry == "export_bpc_cases"){
+        // run_workflow_case_selection(params.phase, params.cohort, params.center, params.production)
+        run_export_bpc_selected_cases(params.bpc_input, params.bpc_output, export_phase, params.cohort, params.center, params.release)
+    } else if (params.entry == "case_selection"){
+        run_workflow_case_selection(params.phase, params.cohort, params.center, params.release, params.production)
+        // run_export_bpc_selected_cases(params.bpc_input, params.bpc_output, params.phase, params.cohort, params.center)
+    } else {
+        error "Invalid entry point: '${params.entry}'. Valid options are: '${valid_entry_points.join(', ')}'"
+    }
 }
 
 // TODO: This is commented out because the two steps currently don't connect together in a smooth way

--- a/subworkflows/nextflow.config
+++ b/subworkflows/nextflow.config
@@ -45,10 +45,4 @@ profiles {
 	case_selection {
 		params.entry = "case_selection"
 	}
-	bpc_pipeline {
-		params.entry = "bpc_pipeline"
-	}
-	clinical_release {
-		params.entry = "clinical_release"
-	}
 }

--- a/subworkflows/nextflow.config
+++ b/subworkflows/nextflow.config
@@ -39,4 +39,16 @@ profiles {
 			}
 		}
 	}
+	export_bpc_cases {
+		params.entry = "export_bpc_cases"
+	}
+	case_selection {
+		params.entry = "case_selection"
+	}
+	bpc_pipeline {
+		params.entry = "bpc_pipeline"
+	}
+	clinical_release {
+		params.entry = "clinical_release"
+	}
 }


### PR DESCRIPTION
# **Problem:**
There will be a breaking change for when Seqera Platform upgrades to Nextflow >= 24.10.0. The [`entry` option](https://www.nextflow.io/docs/latest/reference/cli.html#cli-reference) will become deprecated.

Example of our case selection workflow that uses this to-be deprecated`entry` when we specify by workflow entry name in the nextflow UI
```
nextflow run 'https://github.com/Sage-Bionetworks/genie-bpc-pipeline'
		 -name ESOPHAGO_VICC_2_case_selection
		 -r develop
		 -profile aws_prod
		 -entry case_selection
```

# **Solution:**
See this [PR in nf-synapse](https://github.com/Sage-Bionetworks-Workflows/nf-synapse/pull/11) for the original method that was copy and pasted here. 

Implemented `params.entry` instead of using nextflow's to-be deprecated entry option. Created profiles for each of our bpc workflows which set the `params.entry` accordingly.

# **Testing:**
- Added parameter validation
- Launched on Nextflow (removed entry workflow spec and launched with `bpc_pipeline` profile)
- Launched on Nextflow (removed entry workflow spec and launched with `case_selection` profile)

Testing report here: 
https://sagebionetworks.jira.com/browse/GEN-1773?focusedCommentId=263458