### PR TITLE
[GEN-2025] table schema update staging mode

### DIFF
--- a/scripts/table_updates/README.md
+++ b/scripts/table_updates/README.md
@@ -46,11 +46,15 @@ Prepare the Synapse tables to be updated
 ##### Step 1. Update the Data Catalog
 
 ###### Example 1: Update the data element catalog using the data dictionary:
+1. production mode
+```
+python update_data_element_catalog.py dd -v [prissmm_version_number] -p
+```
+2. staging mode
 ```
 python update_data_element_catalog.py dd -v [prissmm_version_number]
 ```
-
-###### Example 2: Update the data element catalog using the scope of release (not in use):
+###### Example 2: Update the data element catalog using the scope of release (DEPRECATED):
 ```
 python update_data_element_catalog.py sor
 ```
@@ -62,9 +66,18 @@ python update_data_element_catalog.py --dry_run dd -v v3.1.1
 ```
 
 ##### Step 2. Update the table schema
-
+###### Example 1: Update table schema
+1. production mode
+```
+python update_table_schema.py -p
+```
+2. staging mode
 ```
 python update_table_schema.py
+```
+###### Example 2: Update table schema dry run mode
+```
+python update_table_schema.py --dry_run
 ```
 
 # Update Data Table

--- a/scripts/table_updates/README.md
+++ b/scripts/table_updates/README.md
@@ -56,6 +56,7 @@ python update_data_element_catalog.py sor
 ```
 
 ###### Example 3: Dry run for data dictionary update:
+This skips the actual schema updates and only logs the intended changes. This is useful for testing.
 ```
 python update_data_element_catalog.py --dry_run dd -v v3.1.1
 ```

--- a/scripts/table_updates/README.md
+++ b/scripts/table_updates/README.md
@@ -45,8 +45,19 @@ Prepare the Synapse tables to be updated
 
 ##### Step 1. Update the Data Catalog
 
+###### Example 1: Update the data element catalog using the data dictionary:
 ```
-python update_data_element_catalog.py -v [prissmm_version_number]
+python update_data_element_catalog.py dd -v [prissmm_version_number]
+```
+
+###### Example 2: Update the data element catalog using the scope of release (not in use):
+```
+python update_data_element_catalog.py sor
+```
+
+###### Example 3: Dry run for data dictionary update:
+```
+python update_data_element_catalog.py --dry_run dd -v v3.1.1
 ```
 
 ##### Step 2. Update the table schema

--- a/scripts/table_updates/update_data_element_catalog.py
+++ b/scripts/table_updates/update_data_element_catalog.py
@@ -1,19 +1,25 @@
 # !/usr/bin/python
-'''
-Example:
-python update_data_element_catalog.py -v v3.1.1
-'''
+"""
+Example 1: Update the data element catalog using the data dictionary:
+python update_data_element_catalog.py dd -v v3.1.1
+
+Example 2: Update the data element catalog using the scope of release (not in use):
+python update_data_element_catalog.py sor
+
+Example 3: Dry run for data dictionary update:
+python update_data_element_catalog.py --dry_run dd -v v3.1.1
+"""
 import argparse
 import re
-import pandas
-import numpy
 
+import pandas
+import synapseclient
+from synapseclient import Column
+from synapseclient.models import Table
 from utilities import *
 
-CATALOG_ID = "syn21431364"
-SOR_ID = "syn22294851"
 
-def set_up(args):
+def set_up(args: argparse.Namespace):
     """Set up with the genereal arguments
 
     Args:
@@ -21,46 +27,76 @@ def set_up(args):
 
     Returns:
         list: dry run flag, synapse login, and logger
+        syn: Synapse login object
+        logger: logger for tracking
+        CATALOG_ID: Synapse ID of GENIE BPC No PHI Data Elements Catalog
+        SOR_ID: Synapse ID of Scope of Release file
     """
     dry_run = args.dry_run
-
-    #login to synapse
+    # login to synapse
     syn = synapse_login(args.synapse_config)
-    
-    #create logger
-    logger_name = "testing" if dry_run else "production"
+
+    # create logger
+    logger_name = "staging" if dry_run else "production"
     logger = setup_custom_logger(logger_name)
-    logger.info('Updating BPC data element catalog!')
-    return dry_run, syn, logger
+    logger.info("Updating BPC data element catalog!")
+    if args.production:
+        CATALOG_ID = "syn21431364"
+        SOR_ID = "syn22294851"
+    else:
+        # staging environment
+        CATALOG_ID = "syn68893705"
+        SOR_ID = "syn63611274"
 
-def _get_dd_info(syn, version):
-    """
-    Get the non-PHI data dictionary Synapse ID and cohort by version number
-    """
-    prissmm_info = syn.tableQuery("SELECT id, name, cohort FROM syn22684834 WHERE name=\'%s\'" % version).asDataFrame()
-    #TODO: error message if the version does not exist
-    for file_info in syn.getChildren(prissmm_info['id'][0]):
-        if file_info['name'] == "Data Dictionary non-PHI":
-            syn_id = file_info['id']
-    return syn_id, prissmm_info['cohort'][0]
+    return dry_run, syn, logger, CATALOG_ID, SOR_ID
 
-def _get_choices_info(choices):
+
+def _get_dd_info(syn: synapseclient.Synapse, version: str) -> tuple[str, str]:
+    """
+    Get the PRISSMM non-PHI data dictionary Synapse ID and its associated cohort by version number
+    """
+    prissmm_info = syn.tableQuery(
+        "SELECT id, name, cohort FROM syn22684834 WHERE name='%s'" % version
+    ).asDataFrame()
+    # TODO: error message if the version does not exist
+    for file_info in syn.getChildren(prissmm_info["id"][0]):
+        if file_info["name"] == "Data Dictionary non-PHI":
+            syn_id = file_info["id"]
+    return syn_id, prissmm_info["cohort"][0]
+
+
+def _get_choices_info(choices: pandas.Series) -> pandas.Series:
     """
     Get the number of choices and max length of choices for given choices
+
+    Args:
+        choices: pandas.Series of choices in the format of "key1, value1|key2, value2|..."
+
+    Returns:
+        pandas.Series: a series with number of choices, max length of choices, and keys of choices
     """
-    choices_list = choices.split('|')
-    choices_keys, choices_list = map(list, zip(*(s.split(',',1) for s in choices_list)))
+    choices_list = choices.split("|")
+    choices_keys, choices_list = map(
+        list, zip(*(s.split(",", 1) for s in choices_list))
+    )
     choices_keys = [s.strip() for s in choices_keys]
     choices_keys = ",".join(choices_keys)
     choices_list = [s.strip() for s in choices_list]
     max_len = len(max(choices_list, key=len))
     # round up the max length to the nearest 10
-    max_len = round((max_len+4)/10)*10
-    return pandas.Series([len(choices_list),max_len,choices_keys])
+    max_len = round((max_len + 4) / 10) * 10
+    return pandas.Series([len(choices_list), max_len, choices_keys])
 
-def _get_syn_col_type(var_type, validation):
+
+def _get_syn_col_type(var_type: str, validation: str) -> str:
     """
     Get Synapse Table column type by variable type and validation
+
+    Args:
+        var_type: variable type
+        validation: validation type
+    Returns:
+        str: Synapse Table column type string
     """
     if validation == "integer":
         return "INTEGER"
@@ -71,104 +107,190 @@ def _get_syn_col_type(var_type, validation):
     else:
         return "STRING"
 
-def _create_new_row(df, cohort):
+
+def _create_new_row(df: pandas.DataFrame, cohort: str) -> pandas.DataFrame:
     """
-    Create new row for updating the data element catalog
+    Add new rows for variables introduced in the specified version of the data dictionary to the data element catalog table.
+
+    Args:
+        df:  The dataframe contains the variables to be added.
+        cohort: Name of the cohort associated with the data dictionary.
+
+    Returns:
+        pandas.DataFrame: A new row containing the necessary columns for the data element catalog.
     """
-    # add new and update old variables to data element catalog on Synapse
     # add: variable, instrument, dataType='curated', type, label, cohort_dd, synColType, synColSize, numCols, colLabels
-    df['synColType'] = df.apply(lambda row: _get_syn_col_type(row.type,row.validation), axis=1)
-    df_choices = df[df['type'].isin(['dropdown','radio','checkbox'])]
-    df_choices.loc[:, ['choices_num','max_len','choices_key']] = df_choices['choices'].apply(_get_choices_info)
-    # df_choices[['choices_num','max_len','choices_key']] = df_choices['choices'].apply(_get_choices_info)
-    non_checkbox_index = df_choices.index[df_choices.type.isin(['dropdown','radio'])]
+    df["synColType"] = df.apply(
+        lambda row: _get_syn_col_type(row.type, row.validation), axis=1
+    )
+    # Calculate the new choices_num, max_len, and choices_key for variables with choices
+    df_choices = df[df["type"].isin(["dropdown", "radio", "checkbox"])]
+    df_choices.loc[:, ["choices_num", "max_len", "choices_key"]] = df_choices[
+        "choices"
+    ].apply(_get_choices_info)
+    non_checkbox_index = df_choices.index[df_choices.type.isin(["dropdown", "radio"])]
     checkbox_index = df_choices.index[df_choices.type == "checkbox"]
-    df.loc[non_checkbox_index,'synColSize'] = df_choices.loc[non_checkbox_index,'max_len']
+    # for non-checkbox type, update synColSize only since no new columns will be added
+    if len(non_checkbox_index) > 0:
+        df.loc[non_checkbox_index, "synColSize"] = df_choices.loc[
+            non_checkbox_index, "max_len"
+        ]
+    # update numCols and colLabels for checkbox type
     if len(checkbox_index) > 0:
-        df.loc[checkbox_index, ['synColSize','numCols','colLabels']] = df_choices.loc[non_checkbox_index,['max_len','choices_num','choices_key']]
-    df.loc[df.type=="yesno", 'synColSize'] = 20
-    # df.loc[checkbox_index,['synColSize','numCols','colLabels']] = df_choices.loc[non_checkbox_index,['max_len','choices_num','choices_key']]
-    # df.loc[df.type=="yesno",'synColSize'] = 20
-    df['dataType'] = 'curated'
-    df[cohort+'_dd'] = True
-    df.drop(columns=['choices','validation'],axis=1,inplace=True)
+        df.loc[checkbox_index, ["synColSize", "numCols", "colLabels"]] = df_choices.loc[
+            checkbox_index, ["max_len", "choices_num", "choices_key"]
+        ]
+    df.loc[df.type == "yesno", "synColSize"] = 20
+    df["dataType"] = "curated"
+    df[cohort + "_dd"] = True
+    df.drop(columns=["choices", "validation"], axis=1, inplace=True)
     return df
 
-def _update_by_data_dictionary(data_dictionary, data_element_catalog, logger):
+
+def _update_by_data_dictionary(
+    data_dictionary: pandas.DataFrame,
+    data_element_catalog: pandas.DataFrame,
+    logger: logging,
+) -> tuple[pandas.DataFrame, pandas.DataFrame, pandas.DataFrame]:
     """
     Compare data dictionary and data element catalog
+
+    Args:
+        data_dictionary: pandas.DataFrame of data dictionary
+        data_element_catalog: pandas.DataFrame of data element catalog
+        logger: logger for tracking
+
+    Returns:
+        tuple: (vars_to_add_df, vars_to_rm_df, vars_to_update_df)
     """
     # check for the variables that need to be added and removed
-    dd_vars = data_dictionary['variable']
-    dec_vars = data_element_catalog['variable']
-    vars_to_add = list(set(dd_vars)-set(dec_vars))
-    vars_to_add_df = data_dictionary[data_dictionary['variable'].isin(vars_to_add)]
-    vars_to_rm = list(set(dec_vars)-set(dd_vars))
-    vars_to_rm_df = data_element_catalog[data_element_catalog['variable'].isin(vars_to_rm)]
-    logger.info("Number of new variables: %s \n" % len(vars_to_add)+'\n'.join(vars_to_add))
-    logger.info("Number of removed variables: %s \n" % len(vars_to_rm)+'\n'.join(vars_to_rm))
-    # check for variable wtih choices to update 
-    vars_with_choices = data_dictionary[data_dictionary['type'].isin(['dropdown','radio','checkbox'])]
+    dd_vars = data_dictionary["variable"]
+    dec_vars = data_element_catalog["variable"]
+    # add variables that are in data dictionary but not in data element catalog
+    vars_to_add = list(set(dd_vars) - set(dec_vars))
+    vars_to_add_df = data_dictionary[data_dictionary["variable"].isin(vars_to_add)]
+    # remove variables that are in data element catalog but not in data dictionary
+    vars_to_rm = list(set(dec_vars) - set(dd_vars))
+    vars_to_rm_df = data_element_catalog[
+        data_element_catalog["variable"].isin(vars_to_rm)
+    ]
+    logger.info(
+        "Number of new variables: %s \n" % len(vars_to_add) + "\n".join(vars_to_add)
+    )
+    # not removing any variables for now since older data dictionaries might still be used for older data
+    # logger.info("Number of removed variables: %s \n" % len(vars_to_rm)+'\n'.join(vars_to_rm))
+    # check for variables with choices to update in the data element catalog based on changes in the data dictionary
+    vars_with_choices = data_dictionary[
+        data_dictionary["type"].isin(["dropdown", "radio", "checkbox"])
+    ]
     vars_with_choices = vars_with_choices.merge(data_element_catalog, on="variable")
-    vars_with_choices.index = vars_with_choices['index']
-    vars_with_choices[['choices_num','max_len','choices_key']] = vars_with_choices['choices'].apply(_get_choices_info)
+    vars_with_choices.index = vars_with_choices["index"]
+    # calculate the number of choices, max length of choices, and keys of choices for each variable
+    vars_with_choices[["choices_num", "max_len", "choices_key"]] = vars_with_choices[
+        "choices"
+    ].apply(_get_choices_info)
     # check for variables with choices that the max_len(choices) > synColSize
-    # TODO: yesno can be changed to choices 
-    vars_to_update = vars_with_choices.query('(max_len > synColSize) or synColSize.isna()')
-    vars_to_update['synColSize'] = vars_to_update['max_len']
-    # check for number of checkbox variables > numCols
-    # check for null values
-    vars_checkbox = vars_with_choices[vars_with_choices['type']=='checkbox']
-    vars_checkbox_update = vars_checkbox.query('(choices_num > numCols) or numCols.isna()')
-    vars_checkbox_update['numCols'] = vars_checkbox_update['choices_num']
-    vars_checkbox_update['colLabels'] = vars_checkbox_update['choices_key']
-    # combined variables for update
-    index_to_update = vars_to_update.index[vars_to_update['variable'].isin(vars_checkbox_update['variable'])]
-    vars_to_update.loc[index_to_update,'numCols'] = vars_checkbox_update.loc[index_to_update,'numCols']
-    vars_to_update.loc[index_to_update,'colLabels'] = vars_checkbox_update.loc[index_to_update,'colLabels']
-    vars_checkbox_update.drop(index=index_to_update,inplace=True)
-    vars_to_update_df = pandas.concat([vars_to_update, vars_checkbox_update])
-    # vars_to_update_df = vars_to_update.append(vars_checkbox_update)
+    # TODO: yesno can be changed to choices
+    # update synColSize if any changes
+    vars_to_update = vars_with_choices.query(
+        "(max_len > synColSize) | (synColSize.isna())"
+    )
+    vars_to_update["synColSize"] = vars_to_update["max_len"]
+
+    # Update numCols and colLabels for checkbox type if any changes
+    vars_checkbox_update = vars_with_choices.query(
+        'type == "checkbox" and ((choices_num > numCols) | (numCols.isna()))'
+    )
+    vars_checkbox_update["synColSize"] = vars_checkbox_update["max_len"]
+    vars_checkbox_update["numCols"] = vars_checkbox_update["choices_num"]
+    vars_checkbox_update["colLabels"] = vars_checkbox_update["choices_key"]
+
+    # Combine variables for update, avoiding duplicates
+    vars_to_update_df = pandas.concat(
+        [
+            vars_to_update[
+                ~vars_to_update["variable"].isin(vars_checkbox_update["variable"])
+            ],
+            vars_checkbox_update,
+        ]
+    )
+    both_size_number_index = list(
+        set(vars_to_update.index).intersection(set(vars_checkbox_update.index))
+    )
     logger.info("Number of updated variables: %s" % vars_to_update_df.shape[0])
-    logger.info("Updated Synapse column size: %s \n" % vars_to_update.shape[0]+'\n'.join(vars_to_update['variable']))
-    logger.info("Updated Synapse column number only: %s \n" % vars_checkbox_update.shape[0]+'\n'.join(vars_checkbox_update['variable']))
-    logger.info("Updated both columns size and number: %s \n" % +len(index_to_update)+'\n'.join(vars_to_update.loc[index_to_update, 'variable']))
+    logger.info(
+        "Updated Synapse column size: %s \n" % vars_to_update.shape[0]
+        + "\n".join(vars_to_update["variable"])
+    )
+    logger.info(
+        "Updated Synapse column number only: %s \n" % vars_checkbox_update.shape[0]
+        + "\n".join(vars_checkbox_update["variable"])
+    )
+    logger.info(
+        "Updated both columns size and number: %s \n" % +len(both_size_number_index)
+        + "\n".join(vars_to_update.loc[both_size_number_index, "variable"])
+    )
     return vars_to_add_df, vars_to_rm_df, vars_to_update_df
 
-#TODO: 
+
+# TODO:
 # combine the add/update/remove into one syn.store
 # determine the procedure for variables of removal
 def update_by_data_dictionary(args):
-    dry_run, syn, logger = set_up(args)
+    dry_run, syn, logger, CATALOG_ID, SOR_ID = set_up(args)
     dd_syn_id, cohort = _get_dd_info(syn, args.version)
-    data_dictionary = pandas.read_csv(syn.get(dd_syn_id).path,
-                                      usecols=[0,1,3,4,5,7],
-                                      header=0, 
-                                      names=["variable","instrument","type","label","choices","validation"]
-                                      )
-    curated_var_catalog = syn.tableQuery("SELECT variable, synColSize, numCols \
-        FROM %s WHERE dataType='curated'" % CATALOG_ID).asDataFrame()
+    # load data dictionary
+    data_dictionary = pandas.read_csv(
+        syn.get(dd_syn_id).path,
+        usecols=[0, 1, 3, 4, 5, 7],
+        header=0,
+        names=["variable", "instrument", "type", "label", "choices", "validation"],
+    )
+    # extract curated data from data element catalog table
+    curated_var_catalog = syn.tableQuery(
+        "SELECT variable, synColSize, numCols \
+        FROM %s WHERE dataType='curated'"
+        % CATALOG_ID
+    ).asDataFrame()
     curated_var_catalog.index = curated_var_catalog.index.map(str)
-    curated_var_catalog['index'] = curated_var_catalog.index
-    vars_to_add_df, vars_to_rm_df, vars_to_update_df = \
-        _update_by_data_dictionary(data_dictionary, curated_var_catalog, logger)
+    curated_var_catalog["index"] = curated_var_catalog.index
+    #
+    vars_to_add_df, vars_to_rm_df, vars_to_update_df = _update_by_data_dictionary(
+        data_dictionary, curated_var_catalog, logger
+    )
     # add new and update old variables to data element catalog on Synapse
-        # add: variable, instrument, dataType='curated', type, label, cohort-dd, synColType, synColSize, numCols
-        # update: variable, synColSize, numCols
+    # add: variable, instrument, dataType='curated', type, label, cohort-dd, synColType, synColSize, numCols
+    # update: variable, synColSize, numCols
     if not dry_run:
-        if not vars_to_update_df.empty: 
-            vars_to_update_df = vars_to_update_df[['synColSize','numCols','colLabels']]
-            vars_to_update_df = syn.store(Table(CATALOG_ID, vars_to_update_df))
-        if not vars_to_add_df.empty: 
+        table_schema = syn.get(CATALOG_ID)
+        results = syn.tableQuery("select * from %s" % CATALOG_ID)
+        if not vars_to_update_df.empty:
+            vars_to_update_df = vars_to_update_df[
+                ["synColSize", "numCols", "colLabels"]
+            ]
+            vars_to_update_df = syn.store(
+                Table(table_schema, vars_to_update_df, etag=results.etag)
+            )
+        if not vars_to_add_df.empty:
             vars_to_add_df = _create_new_row(vars_to_add_df, cohort)
-            vars_to_add_df = syn.store(Table(CATALOG_ID, vars_to_add_df))
+            # add the new cohort_dd column to the table schema
+            if "%s_dd" % cohort not in results.asDataFrame().columns:
+                new_col = syn.store(Column(name="%s_dd" % cohort, columnType="BOOLEAN"))
+                table_schema.addColumn(new_col)
+                syn.store(table_schema)
+            syn.store(Table(table_schema, vars_to_add_df))
+            syn.create_snapshot_version(
+                table=CATALOG_ID, comment="%s_%s" % (cohort, args.version)
+            )
 
-def download_bpc_sor(syn, logger):
-    """Download the BPC Scope of Release
+
+def download_bpc_sor(syn, logger, SOR_ID):
+    """Download the BPC Scope of Release File
 
     Args:
         syn (Object): Synapse Credential
         logger (Object): logger for tracking
+        SOR_ID: Synapse ID of Scope of Release file
 
     Returns:
         pandas.DataFrame: Scope of Release
@@ -177,18 +299,22 @@ def download_bpc_sor(syn, logger):
     sor = pandas.read_excel(syn.get(SOR_ID).path, sheet_name="Data Dictionary")
     # get the list of columns we need
     sor.columns = sor.columns.str.lower()
-    sor = sor.filter(regex='^varname|^type|dataset|display name|shared|cbio')
+    sor = sor.filter(regex="^varname|^type|dataset|display name|shared|cbio")
     # rename the columns
-    sor.drop(columns=['cbio varname'],inplace=True)
-    sor.rename(columns={'varname': 'variable', 
-                        'type': 'dataType',
-                        'display name': 'label'}, 
-               inplace=True)
-    sor.loc[:, ~sor.columns.isin(['dataset','label'])] = \
-        sor.loc[:, ~sor.columns.isin(['dataset','label'])].apply(lambda x: x.str.lower())
-    sor.dataType.replace(['project genie tier 1 data', 'tumor registry'],'curated',inplace=True)
+    sor.drop(columns=["cbio varname"], inplace=True)
+    sor.rename(
+        columns={"varname": "variable", "type": "dataType", "display name": "label"},
+        inplace=True,
+    )
+    sor.loc[:, ~sor.columns.isin(["dataset", "label"])] = sor.loc[
+        :, ~sor.columns.isin(["dataset", "label"])
+    ].apply(lambda x: x.str.lower())
+    sor.dataType.replace(
+        ["project genie tier 1 data", "tumor registry"], "curated", inplace=True
+    )
     sor.variable = sor.variable.str.strip()
     return sor
+
 
 def _select_columns_by_release_info(col_list, cohort, release_version, logger):
     """Helper function to find the columns with given release information
@@ -208,17 +334,35 @@ def _select_columns_by_release_info(col_list, cohort, release_version, logger):
     """
     if str(release_version) == "1.1":
         release_version = "1"
-    r = re.compile(".*%s.*%s.*" % (cohort.lower(),str(release_version)))
+    if str(release_version) == "1.0" and cohort.lower() == "brca":
+        release_version = "1"
+        r = re.compile(
+            ".*%s.*%s |.*%s.*%s$"
+            % (
+                cohort.lower(),
+                str(release_version),
+                cohort.lower(),
+                str(release_version),
+            )
+        )
+    else:
+        r = re.compile(".*%s.*%s.*" % (cohort.lower(), str(release_version)))
     related_columns = list(filter(r.match, col_list))
     if len(related_columns) != 2:
-        logger.error("Cannot find 2 columns in sor file for %s v%s" %(cohort, release_version))
-        raise Exception("Please check the scope of release file. Cannot find the 2 columns.")
+        logger.error(
+            "Cannot find columns in sor file for %s v%s" % (cohort, release_version)
+        )
+        raise Exception(
+            "Please check the scope of release file. Cannot find the %s v%s associated columns."
+            % (cohort, release_version)
+        )
     for col in related_columns:
         if "cbio" in col:
             cbio_col_name = col
         else:
             clinical_col_name = col
     return [clinical_col_name, cbio_col_name]
+
 
 def _get_release_type_by_info(clinical_release, cbio_release, release_type):
     """Helper function to get release type in Data Element Catalog
@@ -231,7 +375,7 @@ def _get_release_type_by_info(clinical_release, cbio_release, release_type):
     Returns:
         str: release type in Data Element Catalog
     """
-    yes_value_list = ["yes","always","index cancer only","non-index cancer only"]
+    yes_value_list = ["yes", "always", "index cancer only", "non-index cancer only"]
     dec_release_type = "private"
     if release_type == "consortium":
         release_type = "project"
@@ -240,6 +384,7 @@ def _get_release_type_by_info(clinical_release, cbio_release, release_type):
     elif cbio_release in yes_value_list:
         dec_release_type = "consortium"
     return dec_release_type
+
 
 def _process_release_type(var_row, release_info):
     """Helper function to process the release type per row
@@ -253,11 +398,14 @@ def _process_release_type(var_row, release_info):
     """
     temp_dict = {}
     for _, cohort_row in release_info.iterrows():
-        dec_release_type = _get_release_type_by_info(var_row[cohort_row['clinical_col_name']],
-                                                     var_row[cohort_row['cbio_col_name']],
-                                                     cohort_row['release_type'])
-        temp_dict[cohort_row['cohort']+"_sor"] = dec_release_type
+        dec_release_type = _get_release_type_by_info(
+            var_row[cohort_row["clinical_col_name"]],
+            var_row[cohort_row["cbio_col_name"]],
+            cohort_row["release_type"],
+        )
+        temp_dict[cohort_row["cohort"] + "_sor"] = dec_release_type
     return pandas.Series(temp_dict)
+
 
 def format_bpc_sor(sor, release_info, logger):
     """Format Scope of Release with DEC release type columns
@@ -271,98 +419,123 @@ def format_bpc_sor(sor, release_info, logger):
         pandas.DataFrame: Scope of Release with expected DEC release type
     """
     # Format sor by removing dup variables
-    sor['variable'] = sor['variable'].apply(lambda x: re.sub(r"""___\d+""","", x))
-    sor.drop_duplicates(['variable','dataset'],inplace=True)
+    sor["variable"] = sor["variable"].apply(lambda x: re.sub(r"""___\d+""", "", x))
+    sor.drop_duplicates(["variable", "dataset"], inplace=True)
     # Remove Synapse Tables variables
     r = re.compile("synapse_*")
     syn_table_vars = list(filter(r.match, sor.variable))
-    sor.drop(sor.loc[sor['variable'].isin(syn_table_vars)].index, inplace=True)
-    logger.info('Removing Synapse Table variables...')
+    sor.drop(sor.loc[sor["variable"].isin(syn_table_vars)].index, inplace=True)
+    logger.info("Removing Synapse Table variables...")
     # Add release status columns to release info
-    release_info[['clinical_col_name', 'cbio_col_name']] = \
-        release_info.apply(lambda x: _select_columns_by_release_info(list(sor.columns),
-                                                                     x['cohort'],
-                                                                     x['release_version'],
-                                                                     logger),
-                           result_type='expand', axis=1)
+    release_info[["clinical_col_name", "cbio_col_name"]] = release_info.apply(
+        lambda x: _select_columns_by_release_info(
+            list(sor.columns), x["cohort"], x["release_version"], logger
+        ),
+        result_type="expand",
+        axis=1,
+    )
     # Add release scope columns to sor
-    sor_formatted = sor.join(sor.apply(lambda x: _process_release_type(x, release_info), 
-                                       axis="columns"))
+    sor_formatted = sor.join(
+        sor.apply(lambda x: _process_release_type(x, release_info), axis="columns")
+    )
     return sor_formatted
 
+
 def _update_by_release_scope(sor_formatted, data_element_catalog, logger):
-    sor_derived_vars = set(sor_formatted[sor_formatted['dataType']=="derived"]['variable'])
-    if 'redacted' in sor_derived_vars:
-        sor_derived_vars.remove('redacted')
-    dec_derived_vars = set(data_element_catalog[data_element_catalog['dataType']=="derived"]['variable'])
+    sor_derived_vars = set(
+        sor_formatted[sor_formatted["dataType"] == "derived"]["variable"]
+    )
+    if "redacted" in sor_derived_vars:
+        sor_derived_vars.remove("redacted")
+    dec_derived_vars = set(
+        data_element_catalog[data_element_catalog["dataType"] == "derived"]["variable"]
+    )
     r = re.compile(".*_sor")
     sor_columns = list(filter(r.match, sor_formatted.columns))
     # variables to add
-    vars_to_add = list(sor_derived_vars-dec_derived_vars)
-    vars_to_add_df = sor_formatted[sor_formatted['variable'].isin(vars_to_add)]
-    vars_to_add_df_col = ['variable','dataType','dataset','label']+sor_columns
+    vars_to_add = list(sor_derived_vars - dec_derived_vars)
+    vars_to_add_df = sor_formatted[sor_formatted["variable"].isin(vars_to_add)]
+    vars_to_add_df_col = ["variable", "dataType", "dataset", "label"] + sor_columns
     vars_to_add_df = vars_to_add_df[vars_to_add_df_col]
     # variables to remove
-    vars_to_rm = list(dec_derived_vars-sor_derived_vars)
-    logger.info("Number of new derived variables: %s \n" % len(vars_to_add)+'\n'.join(vars_to_add))
-    logger.info("Number of removed derived variables: %s \n" % len(vars_to_rm)+'\n'.join(vars_to_rm))
+    vars_to_rm = list(dec_derived_vars - sor_derived_vars)
+    logger.info(
+        "Number of new derived variables: %s \n" % len(vars_to_add)
+        + "\n".join(vars_to_add)
+    )
+    logger.info(
+        "Number of removed derived variables: %s \n" % len(vars_to_rm)
+        + "\n".join(vars_to_rm)
+    )
     # TODO: variables to update; waiting for stats team
-    vars_to_update_df = ""
+    vars_to_update_df = pandas.DataFrame()
     return vars_to_add_df, vars_to_rm, vars_to_update_df
-    
+
+
 def update_by_release_scope(args):
-    dry_run, syn, logger = set_up(args)
-    sor = download_bpc_sor(syn, logger)
-    release_info = syn.tableQuery("SELECT cohort, release_version, release_type \
+    dry_run, syn, logger, CATALOG_ID, SOR_ID = set_up(args)
+    sor = download_bpc_sor(syn, logger, SOR_ID)
+    release_info = syn.tableQuery(
+        "SELECT cohort, release_version, release_type \
                                    FROM syn27628075 \
-                                   WHERE current is true").asDataFrame()
+                                   WHERE current is true"
+    ).asDataFrame()
     sor_formatted = format_bpc_sor(sor, release_info, logger)
     data_element_catalog_query = syn.tableQuery("SELECT * FROM %s" % CATALOG_ID)
     data_element_catalog = data_element_catalog_query.asDataFrame()
-    vars_to_add_df, vars_to_rm_df, vars_to_update_df = \
-        _update_by_release_scope(sor_formatted, data_element_catalog, logger)
+    vars_to_add_df, vars_to_rm_df, vars_to_update_df = _update_by_release_scope(
+        sor_formatted, data_element_catalog, logger
+    )
     if not dry_run:
         table_schema = syn.get(CATALOG_ID)
         if not vars_to_update_df.empty:
-            syn.store(Table(table_schema, vars_to_update_df, 
-                            etag=data_element_catalog_query.etag))
+            syn.store(
+                Table(
+                    table_schema,
+                    vars_to_update_df,
+                    etag=data_element_catalog_query.etag,
+                )
+            )
         if not vars_to_add_df.empty:
             logger.info("Adding new variables to the data element catalog...")
-            syn.store(Table(table_schema,vars_to_add_df))
+            syn.store(Table(table_schema, vars_to_add_df))
+
 
 def main():
-    #add arguments
-    parser = argparse.ArgumentParser(
-        description='Update BPC data element catalog')
+    # add arguments
+    parser = argparse.ArgumentParser(description="Update BPC data element catalog")
     subparsers = parser.add_subparsers()
-    # Create a dd subcommand    
-    parser_dd = subparsers.add_parser('dd', help='update by data dictionary')
+    # Create a dd subcommand
+    parser_dd = subparsers.add_parser("dd", help="update by data dictionary")
     parser_dd.add_argument(
-        "-v", "--version",
-        help="Version of the data dictionary, i.e. v3.1.1"
+        "-v", "--version", help="Version of the data dictionary, i.e. v3.1.1"
     )
     parser_dd.set_defaults(func=update_by_data_dictionary)
-    # Create a sor subcommand       
-    parser_sor = subparsers.add_parser('sor', help='update by scope of release')
+    # Create a sor subcommand
+    parser_sor = subparsers.add_parser("sor", help="update by scope of release")
     parser_sor.set_defaults(func=update_by_release_scope)
     # general commands
     parser.add_argument(
-        "-c", "--synapse_config",
+        "-c",
+        "--synapse_config",
         default=synapseclient.client.CONFIG_FILE,
-        help="Synapse credentials file"
+        help="Synapse credentials file",
     )
+    parser.add_argument("--dry_run", action="store_true", help="dry run flag")
     parser.add_argument(
-        "--dry_run",
+        "-p",
+        "--production",
         action="store_true",
-        help="dry run flag"
+        help="Update production data element catalog, default is staging.",
     )
-    
+
     if len(sys.argv) <= 1:
-        sys.argv.append('--help')
-    
+        sys.argv.append("--help")
+
     args = parser.parse_args()
     if args.func:
         args.func(args)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/table_updates/update_data_element_catalog.py
+++ b/scripts/table_updates/update_data_element_catalog.py
@@ -1,13 +1,7 @@
 # !/usr/bin/python
 """
-Example 1: Update the data element catalog using the data dictionary:
-python update_data_element_catalog.py dd -v v3.1.1
+The script is used to synchronize the data element catalog with the latest data dictionary or scope of release file(no longer in use).
 
-Example 2: Update the data element catalog using the scope of release (not in use):
-python update_data_element_catalog.py sor
-
-Example 3: Dry run for data dictionary update:
-python update_data_element_catalog.py --dry_run dd -v v3.1.1
 """
 import argparse
 import re
@@ -29,26 +23,26 @@ def set_up(args: argparse.Namespace):
         list: dry run flag, synapse login, and logger
         syn: Synapse login object
         logger: logger for tracking
-        CATALOG_ID: Synapse ID of GENIE BPC No PHI Data Elements Catalog
-        SOR_ID: Synapse ID of Scope of Release file
+        catalog_id: Synapse ID of GENIE BPC No PHI Data Elements Catalog
+        sor_id: Synapse ID of Scope of Release file
     """
     dry_run = args.dry_run
     # login to synapse
-    syn = synapse_login(args.synapse_config)
+    syn = synapse_login(debug=args.debug)
 
     # create logger
     logger_name = "staging" if dry_run else "production"
     logger = setup_custom_logger(logger_name)
     logger.info("Updating BPC data element catalog!")
     if args.production:
-        CATALOG_ID = "syn21431364"
-        SOR_ID = "syn22294851"
+        catalog_id = "syn21431364"
+        sor_id = "syn22294851"
     else:
         # staging environment
-        CATALOG_ID = "syn68893705"
-        SOR_ID = "syn63611274"
+        catalog_id = "syn68893705"
+        sor_id = "syn63611274"
 
-    return dry_run, syn, logger, CATALOG_ID, SOR_ID
+    return dry_run, syn, logger, catalog_id, sor_id
 
 
 def _get_dd_info(syn: synapseclient.Synapse, version: str) -> tuple[str, str]:
@@ -237,7 +231,7 @@ def _update_by_data_dictionary(
 # combine the add/update/remove into one syn.store
 # determine the procedure for variables of removal
 def update_by_data_dictionary(args):
-    dry_run, syn, logger, CATALOG_ID, SOR_ID = set_up(args)
+    dry_run, syn, logger, catalog_id, sor_id = set_up(args)
     dd_syn_id, cohort = _get_dd_info(syn, args.version)
     # load data dictionary
     data_dictionary = pandas.read_csv(
@@ -250,7 +244,7 @@ def update_by_data_dictionary(args):
     curated_var_catalog = syn.tableQuery(
         "SELECT variable, synColSize, numCols \
         FROM %s WHERE dataType='curated'"
-        % CATALOG_ID
+        % catalog_id
     ).asDataFrame()
     curated_var_catalog.index = curated_var_catalog.index.map(str)
     curated_var_catalog["index"] = curated_var_catalog.index
@@ -262,8 +256,8 @@ def update_by_data_dictionary(args):
     # add: variable, instrument, dataType='curated', type, label, cohort-dd, synColType, synColSize, numCols
     # update: variable, synColSize, numCols
     if not dry_run:
-        table_schema = syn.get(CATALOG_ID)
-        results = syn.tableQuery("select * from %s" % CATALOG_ID)
+        table_schema = syn.get(catalog_id)
+        results = syn.tableQuery("select * from %s" % catalog_id)
         if not vars_to_update_df.empty:
             vars_to_update_df = vars_to_update_df[
                 ["synColSize", "numCols", "colLabels"]
@@ -280,23 +274,23 @@ def update_by_data_dictionary(args):
                 syn.store(table_schema)
             syn.store(Table(table_schema, vars_to_add_df))
             syn.create_snapshot_version(
-                table=CATALOG_ID, comment="%s_%s" % (cohort, args.version)
+                table=catalog_id, comment="%s_%s" % (cohort, args.version)
             )
 
 
-def download_bpc_sor(syn, logger, SOR_ID):
+def download_bpc_sor(syn, logger, sor_id):
     """Download the BPC Scope of Release File
 
     Args:
         syn (Object): Synapse Credential
         logger (Object): logger for tracking
-        SOR_ID: Synapse ID of Scope of Release file
+        sor_id: Synapse ID of Scope of Release file
 
     Returns:
         pandas.DataFrame: Scope of Release
     """
     logger.info("Downloading BPC Scope of Release...")
-    sor = pandas.read_excel(syn.get(SOR_ID).path, sheet_name="Data Dictionary")
+    sor = pandas.read_excel(syn.get(sor_id).path, sheet_name="Data Dictionary")
     # get the list of columns we need
     sor.columns = sor.columns.str.lower()
     sor = sor.filter(regex="^varname|^type|dataset|display name|shared|cbio")
@@ -473,21 +467,21 @@ def _update_by_release_scope(sor_formatted, data_element_catalog, logger):
 
 
 def update_by_release_scope(args):
-    dry_run, syn, logger, CATALOG_ID, SOR_ID = set_up(args)
-    sor = download_bpc_sor(syn, logger, SOR_ID)
+    dry_run, syn, logger, catalog_id, sor_id = set_up(args)
+    sor = download_bpc_sor(syn, logger, sor_id)
     release_info = syn.tableQuery(
         "SELECT cohort, release_version, release_type \
                                    FROM syn27628075 \
                                    WHERE current is true"
     ).asDataFrame()
     sor_formatted = format_bpc_sor(sor, release_info, logger)
-    data_element_catalog_query = syn.tableQuery("SELECT * FROM %s" % CATALOG_ID)
+    data_element_catalog_query = syn.tableQuery("SELECT * FROM %s" % catalog_id)
     data_element_catalog = data_element_catalog_query.asDataFrame()
     vars_to_add_df, vars_to_rm_df, vars_to_update_df = _update_by_release_scope(
         sor_formatted, data_element_catalog, logger
     )
     if not dry_run:
-        table_schema = syn.get(CATALOG_ID)
+        table_schema = syn.get(catalog_id)
         if not vars_to_update_df.empty:
             syn.store(
                 Table(
@@ -515,12 +509,7 @@ def main():
     parser_sor = subparsers.add_parser("sor", help="update by scope of release")
     parser_sor.set_defaults(func=update_by_release_scope)
     # general commands
-    parser.add_argument(
-        "-c",
-        "--synapse_config",
-        default=synapseclient.client.CONFIG_FILE,
-        help="Synapse credentials file",
-    )
+    parser.add_argument("--debug", action="store_true", help="Synapse Debug Feature")
     parser.add_argument("--dry_run", action="store_true", help="dry run flag")
     parser.add_argument(
         "-p",

--- a/scripts/table_updates/update_data_element_catalog.py
+++ b/scripts/table_updates/update_data_element_catalog.py
@@ -8,8 +8,7 @@ import re
 
 import pandas
 import synapseclient
-from synapseclient import Column
-from synapseclient.models import Table
+from synapseclient import Column, Table
 from utilities import *
 
 
@@ -258,6 +257,7 @@ def update_by_data_dictionary(args):
     if not dry_run:
         table_schema = syn.get(catalog_id)
         results = syn.tableQuery("select * from %s" % catalog_id)
+        saved_to_table = False
         if not vars_to_update_df.empty:
             vars_to_update_df = vars_to_update_df[
                 ["synColSize", "numCols", "colLabels"]
@@ -265,6 +265,8 @@ def update_by_data_dictionary(args):
             vars_to_update_df = syn.store(
                 Table(table_schema, vars_to_update_df, etag=results.etag)
             )
+            saved_to_table = True
+
         if not vars_to_add_df.empty:
             vars_to_add_df = _create_new_row(vars_to_add_df, cohort)
             # add the new cohort_dd column to the table schema
@@ -273,6 +275,9 @@ def update_by_data_dictionary(args):
                 table_schema.addColumn(new_col)
                 syn.store(table_schema)
             syn.store(Table(table_schema, vars_to_add_df))
+            saved_to_table = True
+
+        if saved_to_table:
             syn.create_snapshot_version(
                 table=catalog_id, comment="%s_%s" % (cohort, args.version)
             )

--- a/scripts/table_updates/update_data_element_catalog.py
+++ b/scripts/table_updates/update_data_element_catalog.py
@@ -61,13 +61,14 @@ def _get_dd_info(syn: synapseclient.Synapse, version: str) -> tuple[str, str]:
 
 def _get_choices_info(choices: pandas.Series) -> pandas.Series:
     """
-    Get the number of choices and max length of choices for given choices
+    Get the number of choices, max length of choices and keys of choices for given choice column. The choice column is
+    corresponding to the Choices, Calculations, OR Slider Labels column in the data dictionary file.
 
     Args:
         choices: pandas.Series of choices in the format of "key1, value1|key2, value2|..."
 
     Returns:
-        pandas.Series: a series with number of choices, max length of choices, and keys of choices
+        pandas.Series: a series with number of choices, max length of choices, and keys of choices (in the format of "key1,key2,...")
     """
     choices_list = choices.split("|")
     choices_keys, choices_list = map(
@@ -84,7 +85,7 @@ def _get_choices_info(choices: pandas.Series) -> pandas.Series:
 
 def _get_syn_col_type(var_type: str, validation: str) -> str:
     """
-    Get Synapse Table column type by variable type and validation
+    Get Synapse Table column type by variable type (Field Type column) and validation (Text Validation Type OR Show Slider Number column) from the data dictionary.
 
     Args:
         var_type: variable type
@@ -147,7 +148,15 @@ def _update_by_data_dictionary(
     logger: logging,
 ) -> tuple[pandas.DataFrame, pandas.DataFrame, pandas.DataFrame]:
     """
-    Compare data dictionary and data element catalog
+    Compare data dictionary and data element catalog to find variables to add, remove, and update(choice variables only).
+    1. Add variables that are in data dictionary but not in data element catalog.
+    2. Remove variables that are in data element catalog but not in data dictionary.
+    3. Update variables with choices (variables with the type values: dropdown", "radio", "checkbox") in data element catalog based on changes in data dictionary.
+        Update synColSize if max length of choices > synColSize or synColSize is empty for all choice variables.
+        Update synColSize, numCols and colLabels for checkbox type if number of choices > numCols or numCols is empty.
+
+    Notes:
+    We currently do not remove any variables since older data dictionaries might still be used for older data.
 
     Args:
         data_dictionary: pandas.DataFrame of data dictionary
@@ -155,7 +164,7 @@ def _update_by_data_dictionary(
         logger: logger for tracking
 
     Returns:
-        tuple: (vars_to_add_df, vars_to_rm_df, vars_to_update_df)
+        tuple: (vars_to_add_df, vars_to_rm_df, vars_to_update_df). DataFrames of variables to add, remove, and update.
     """
     # check for the variables that need to be added and removed
     dd_vars = data_dictionary["variable"]
@@ -173,6 +182,9 @@ def _update_by_data_dictionary(
     )
     # not removing any variables for now since older data dictionaries might still be used for older data
     # logger.info("Number of removed variables: %s \n" % len(vars_to_rm)+'\n'.join(vars_to_rm))
+
+    # GETTING VARIABLES TO UPDATE (choice variables only)
+    # TODO: yesno can be changed to choices
     # check for variables with choices to update in the data element catalog based on changes in the data dictionary
     vars_with_choices = data_dictionary[
         data_dictionary["type"].isin(["dropdown", "radio", "checkbox"])
@@ -183,14 +195,15 @@ def _update_by_data_dictionary(
     vars_with_choices[["choices_num", "max_len", "choices_key"]] = vars_with_choices[
         "choices"
     ].apply(_get_choices_info)
-    # check for variables with choices that the max_len(choices) > synColSize
-    # TODO: yesno can be changed to choices
+
+    # UPDATE VARIABLES (synColSize only)
     # update synColSize if any changes
     vars_to_update = vars_with_choices.query(
         "(max_len > synColSize) | (synColSize.isna())"
     )
     vars_to_update["synColSize"] = vars_to_update["max_len"]
 
+    # UPDATE CHECKBOX VARIABLES (synColSize, numCols, colLabels)
     # Update numCols and colLabels for checkbox type if any changes
     vars_checkbox_update = vars_with_choices.query(
         'type == "checkbox" and ((choices_num > numCols) | (numCols.isna()))'
@@ -199,7 +212,7 @@ def _update_by_data_dictionary(
     vars_checkbox_update["numCols"] = vars_checkbox_update["choices_num"]
     vars_checkbox_update["colLabels"] = vars_checkbox_update["choices_key"]
 
-    # Combine variables for update, avoiding duplicates
+    # COMBINING VARIABLES TO UPDATE (CHECKBOX + NON-CHECKBOX)
     vars_to_update_df = pandas.concat(
         [
             vars_to_update[

--- a/scripts/table_updates/update_data_element_catalog.py
+++ b/scripts/table_updates/update_data_element_catalog.py
@@ -196,46 +196,40 @@ def _update_by_data_dictionary(
         "choices"
     ].apply(_get_choices_info)
 
-    # UPDATE VARIABLES (synColSize only)
-    # update synColSize if any changes
-    vars_to_update = vars_with_choices.query(
-        "(max_len > synColSize) | (synColSize.isna())"
+    # UPDATE NON-CHECKBOX VARIABLES (synColSize only)
+    vars_to_update_non_checkbox = vars_with_choices.query(
+        "type != 'checkbox' and (max_len > synColSize) | (synColSize.isna())"
     )
-    vars_to_update["synColSize"] = vars_to_update["max_len"]
+    vars_to_update_non_checkbox["synColSize"] = vars_to_update_non_checkbox["max_len"]
 
     # UPDATE CHECKBOX VARIABLES (synColSize, numCols, colLabels)
     # Update numCols and colLabels for checkbox type if any changes
-    vars_checkbox_update = vars_with_choices.query(
-        'type == "checkbox" and ((choices_num > numCols) | (numCols.isna()))'
+    vars_to_update_checkbox = vars_with_choices.query(
+        'type == "checkbox" and (((choices_num > numCols) | (numCols.isna())) or (max_len > synColSize) | (synColSize.isna()))'
     )
-    vars_checkbox_update["synColSize"] = vars_checkbox_update["max_len"]
-    vars_checkbox_update["numCols"] = vars_checkbox_update["choices_num"]
-    vars_checkbox_update["colLabels"] = vars_checkbox_update["choices_key"]
+    vars_to_update_checkbox["synColSize"] = vars_to_update_checkbox["max_len"]
+    vars_to_update_checkbox["numCols"] = vars_to_update_checkbox["choices_num"]
+    vars_to_update_checkbox["colLabels"] = vars_to_update_checkbox["choices_key"]
 
     # COMBINING VARIABLES TO UPDATE (CHECKBOX + NON-CHECKBOX)
     vars_to_update_df = pandas.concat(
         [
-            vars_to_update[
-                ~vars_to_update["variable"].isin(vars_checkbox_update["variable"])
-            ],
-            vars_checkbox_update,
+            vars_to_update_non_checkbox,
+            vars_to_update_checkbox,
         ]
-    )
-    both_size_number_index = list(
-        set(vars_to_update.index).intersection(set(vars_checkbox_update.index))
     )
     logger.info("Number of updated variables: %s" % vars_to_update_df.shape[0])
     logger.info(
-        "Updated Synapse column size: %s \n" % vars_to_update.shape[0]
-        + "\n".join(vars_to_update["variable"])
+        "Updated Synapse column size: %s \n" % vars_to_update_df.shape[0]
+        + "\n".join(vars_to_update_df["variable"])
     )
     logger.info(
-        "Updated Synapse column number only: %s \n" % vars_checkbox_update.shape[0]
-        + "\n".join(vars_checkbox_update["variable"])
+        "Updated Synapse column number only: %s \n" % vars_to_update_checkbox.shape[0]
+        + "\n".join(vars_to_update_checkbox["variable"])
     )
     logger.info(
-        "Updated both columns size and number: %s \n" % +len(both_size_number_index)
-        + "\n".join(vars_to_update.loc[both_size_number_index, "variable"])
+        "Updated both columns size and number: %s \n" % vars_to_update_checkbox.shape[0]
+        + "\n".join(vars_to_update_checkbox.loc[vars_to_update_checkbox, "variable"])
     )
     return vars_to_add_df, vars_to_rm_df, vars_to_update_df
 
@@ -243,7 +237,12 @@ def _update_by_data_dictionary(
 # TODO:
 # combine the add/update/remove into one syn.store
 # determine the procedure for variables of removal
-def update_by_data_dictionary(args):
+def update_by_data_dictionary(args: argparse.Namespace) -> None:
+    """Update the data element catalog by the data dictionary with specified version.
+
+    Args:
+        args (argparse.Namespace): Arguments from command line.
+    """
     dry_run, syn, logger, catalog_id, sor_id = set_up(args)
     dd_syn_id, cohort = _get_dd_info(syn, args.version)
     # load data dictionary

--- a/scripts/table_updates/update_data_element_catalog.py
+++ b/scripts/table_updates/update_data_element_catalog.py
@@ -129,7 +129,7 @@ def _create_new_row(df: pandas.DataFrame, cohort: str) -> pandas.DataFrame:
         df.loc[non_checkbox_index, "synColSize"] = df_choices.loc[
             non_checkbox_index, "max_len"
         ]
-    # update numCols and colLabels for checkbox type
+    # update synColSize, numCols and colLabels for checkbox variables
     if len(checkbox_index) > 0:
         df.loc[checkbox_index, ["synColSize", "numCols", "colLabels"]] = df_choices.loc[
             checkbox_index, ["max_len", "choices_num", "choices_key"]
@@ -248,7 +248,6 @@ def update_by_data_dictionary(args):
     ).asDataFrame()
     curated_var_catalog.index = curated_var_catalog.index.map(str)
     curated_var_catalog["index"] = curated_var_catalog.index
-    #
     vars_to_add_df, vars_to_rm_df, vars_to_update_df = _update_by_data_dictionary(
         data_dictionary, curated_var_catalog, logger
     )
@@ -512,7 +511,9 @@ def main():
     )
     parser_dd.set_defaults(func=update_by_data_dictionary)
     # Create a sor subcommand
-    parser_sor = subparsers.add_parser("sor", help="update by scope of release")
+    parser_sor = subparsers.add_parser(
+        "sor", help="update by scope of release which is no longer in use"
+    )
     parser_sor.set_defaults(func=update_by_release_scope)
     # general commands
     parser.add_argument("--debug", action="store_true", help="Synapse Debug Feature")

--- a/scripts/table_updates/update_data_element_catalog.py
+++ b/scripts/table_updates/update_data_element_catalog.py
@@ -8,7 +8,8 @@ import re
 
 import pandas
 import synapseclient
-from synapseclient import Column, Table
+from synapseclient import Column
+from synapseclient.models import Table
 from utilities import *
 
 

--- a/scripts/table_updates/update_data_table.py
+++ b/scripts/table_updates/update_data_table.py
@@ -517,7 +517,6 @@ def update_tier1a(
         & (column_mapping_table["cohort"] == cohort),
     ]
     valid_col = subset_column_mapping_table.prissmm_element.tolist()
-    import pdb; pdb.set_trace()
     if not all(item in valid_col for item in bpc_column_list):
         raise ValueError(
             f"Invalid bpc_column_list. Column names should be matching {valid_col}."
@@ -871,7 +870,7 @@ def main():
     label_data["redacted"] = numpy.nan
 
     # update data tables
-    #store_data(syn, master_table, label_data, table_type, cohort, logger, dry_run)
+    store_data(syn, master_table, label_data, table_type, cohort, logger, dry_run)
     if not dry_run:
         if replace_patient_tier1a or replace_sample_tier1a:
             custom_fix_for_tier1a_variable(

--- a/scripts/table_updates/update_data_table.py
+++ b/scripts/table_updates/update_data_table.py
@@ -27,15 +27,8 @@ import numpy
 import pandas
 import synapseclient
 import utilities
-from synapseclient import (
-    Column,
-    Row,
-    RowSet,
-    Schema,
-    Table,
-    as_table_columns,
-    build_table,
-)
+from synapseclient import (Column, Row, RowSet, Schema, Table,
+                           as_table_columns, build_table)
 
 TABLES = {
     "production": {
@@ -524,7 +517,7 @@ def update_tier1a(
         & (column_mapping_table["cohort"] == cohort),
     ]
     valid_col = subset_column_mapping_table.prissmm_element.tolist()
-
+    import pdb; pdb.set_trace()
     if not all(item in valid_col for item in bpc_column_list):
         raise ValueError(
             f"Invalid bpc_column_list. Column names should be matching {valid_col}."
@@ -806,12 +799,6 @@ def main():
         choices=TABLES["production"].keys(),
     )
     parser.add_argument(
-        "-s",
-        "--synapse_config",
-        default=synapseclient.client.CONFIG_FILE,
-        help="Synapse credentials file",
-    )
-    parser.add_argument(
         "-p", "--project_config", default="config.json", help="Project config file"
     )
     parser.add_argument(
@@ -842,10 +829,10 @@ def main():
     )
     parser.add_argument("-m", "--message", default="", help="Version comment")
     parser.add_argument("-d", "--dry_run", action="store_true", help="dry run flag")
+    parser.add_argument("--debug", action="store_true", help="Synapse Debug Feature")
 
     args = parser.parse_args()
     table_type = args.table
-    synapse_config = args.synapse_config
     project_config = args.project_config
     cohort = args.cohort
     production = args.production
@@ -855,7 +842,7 @@ def main():
     dry_run = args.dry_run
 
     # login to synapse
-    syn = utilities.synapse_login(synapse_config)
+    syn = utilities.synapse_login(debug=args.debug)
 
     # create logger
     logger_name = "testing" if dry_run else "production"
@@ -884,7 +871,7 @@ def main():
     label_data["redacted"] = numpy.nan
 
     # update data tables
-    store_data(syn, master_table, label_data, table_type, cohort, logger, dry_run)
+    #store_data(syn, master_table, label_data, table_type, cohort, logger, dry_run)
     if not dry_run:
         if replace_patient_tier1a or replace_sample_tier1a:
             custom_fix_for_tier1a_variable(

--- a/scripts/table_updates/update_table_schema.py
+++ b/scripts/table_updates/update_table_schema.py
@@ -1,14 +1,11 @@
 # !/usr/bin/python
 import argparse
-import pandas
-
 from functools import reduce
 
+import pandas
+from synapseclient import Column
 from utilities import *
 
-TABLE_INFO = {"sage": ('syn23285911',"table_type='data'"),
-              "bpc": ('syn21446696',"table_type='data' and double_curated is false"),
-              "irr": ('syn21446696',"table_type='data' and double_curated is true")}
 
 def copy_table_schema(syn, from_table_id, to_table_id):
     """
@@ -19,185 +16,324 @@ def copy_table_schema(syn, from_table_id, to_table_id):
     to_table_schema.columnIds = from_table_schema.columnIds
     return to_table_schema
 
+
 def create_synapse_column(name, col_type, max_size):
     """
-    Create a new Synapse Column with given info
+    Create a new Synapse Column with given info. ??? may extend, string. use data element column types
     """
-    if col_type in ['INTEGER','DOUBLE','LARGETEXT']:
-        new_column = Column(name=name,
-                            columnType=col_type)
+    if col_type in ["INTEGER", "DOUBLE", "LARGETEXT"]:
+        new_column = Column(name=name, columnType=col_type)
     else:
         max_size = 500 if pandas.isna(max_size) else int(max_size)
-        new_column = Column(name=name,
-                            columnType=col_type, 
-                            maximumSize=max_size)
+        new_column = Column(name=name, columnType=col_type, maximumSize=max_size)
     return new_column
 
+
 def _expand_checkbox_vars(row):
+    """Expand checkbox variables into multiple columns
+
+    Args:
+        row (pd.Series): A row of the data element dataframe
+
+    Returns:
+        pandas.DataFrame: A dataframe with expanded checkbox variables
+    """
     temp_df_list = []
-    if not pandas.isna(row['colLabels']):
-        for label in row['colLabels'].split(','):
+    if not pandas.isna(row["colLabels"]):
+        for label in row["colLabels"].split(","):
             temp_df = {}
-            temp_df['col_name'] = row['variable']+"___"+label
-            temp_df['synColType'] = row['synColType']
-            temp_df['synColSize'] = row['synColSize']
-            temp_df['variable'] = row['variable']
+            temp_df["col_name"] = row["variable"] + "___" + label
+            temp_df["synColType"] = row["synColType"]
+            temp_df["synColSize"] = row["synColSize"]
+            temp_df["variable"] = row["variable"]
             temp_df_list.append(temp_df)
         return pandas.DataFrame(temp_df_list)
+
 
 def _update_table_schema(syn, form, curated_data_element, logger, dry_run):
     form_name = form[0]
     form_df = form[1]
-    form_name_list = form_name.split(', ')
+    form_name_list = form_name.split(", ")
     logger.info("Checking %s" % form_name)
     # get the data frame of variables
-    vars_dec = curated_data_element[curated_data_element.instrument.isin(form_name_list)]
+    vars_dec = curated_data_element[
+        curated_data_element.instrument.isin(form_name_list)
+    ]
     # get the data frame of existing columns
     current_cols_df = pandas.DataFrame()
     for _, row in form_df.iterrows():
-        current_cols = syn.getColumns(row['id'])
+        current_cols = syn.getColumns(row["id"])
         current_cols = pandas.DataFrame(current_cols)
-        current_cols['table_id'] = row['id']
+        current_cols["table_id"] = row["id"]
         current_cols_df = pandas.concat([current_cols_df, current_cols])
     # get the table id with the least columns
-    tbl_with_least_cols = current_cols_df['table_id'].value_counts()
+    tbl_with_least_cols = current_cols_df["table_id"].value_counts()
     tbl_with_least_cols_id = tbl_with_least_cols.idxmin()
     tbl_with_least_cols_ct = tbl_with_least_cols.min()
     # Compare the data element catalog and the current table columns
-    # non-checkbox 
-    non_check_vars = vars_dec[vars_dec.type!="checkbox"]
-    non_check_cols = current_cols_df[~current_cols_df['name'].str.contains("___")]
-    # checkbox 
-    checkbox_vars = vars_dec[vars_dec.type=="checkbox"]
+    # non-checkbox
+    non_check_vars = vars_dec[vars_dec.type != "checkbox"]
+    non_check_cols = current_cols_df[~current_cols_df["name"].str.contains("___")]
+    # checkbox
+    checkbox_vars = vars_dec[vars_dec.type == "checkbox"]
     if len(checkbox_vars) != 0:
-        checkbox_vars_expanded = pandas.concat(list(checkbox_vars.apply(lambda row: _expand_checkbox_vars(row),axis=1)),ignore_index=True)
-        checkbox_cols = current_cols_df[current_cols_df['name'].str.contains("___")]
-        checkbox_cols['variable'] = checkbox_cols['name'].str.split("___",expand=True)[0]
+        checkbox_vars_expanded = pandas.concat(
+            list(checkbox_vars.apply(lambda row: _expand_checkbox_vars(row), axis=1)),
+            ignore_index=True,
+        )
+        checkbox_cols = current_cols_df[current_cols_df["name"].str.contains("___")]
+        checkbox_cols["variable"] = checkbox_cols["name"].str.split("___", expand=True)[
+            0
+        ]
     # columns to add
     cols_to_add = []
-    #  non-checkbox 
-    non_check_to_add = list(set(non_check_vars['variable'])-set(non_check_cols['name']))
+    #  non-checkbox
+    # add columns in data catalog but not in the table
+    non_check_to_add = list(
+        set(non_check_vars["variable"]) - set(non_check_cols["name"])
+    )
     if len(non_check_to_add) != 0:
-        non_check_to_add_df = non_check_vars[non_check_vars.variable.isin(non_check_to_add)]
-        non_check_new_cols = list(non_check_to_add_df.apply(lambda x: create_synapse_column(x['variable'],x['synColType'],x['synColSize']),axis=1))
+        non_check_to_add_df = non_check_vars[
+            non_check_vars.variable.isin(non_check_to_add)
+        ]
+        non_check_new_cols = list(
+            non_check_to_add_df.apply(
+                lambda x: create_synapse_column(
+                    x["variable"], x["synColType"], x["synColSize"]
+                ),
+                axis=1,
+            )
+        )
         cols_to_add = cols_to_add + non_check_new_cols
-    logger.info('Number of non-checkbox variables to add %s \n' % len(non_check_to_add)+'\n'.join(non_check_to_add))
-    #TODO: non_check_to_rm
-    #  checkbox 
+    logger.info(
+        "Number of non-checkbox variables to add %s \n" % len(non_check_to_add)
+        + "\n".join(non_check_to_add)
+    )
+    # TODO: non_check_to_rm
+    #  checkbox
     if len(checkbox_vars) != 0:
         # new checkbox variables
-        checkbox_to_add = list(set(checkbox_vars['variable'])-set(checkbox_cols['variable']))
-        logger.info('Number of checkbox variables to add: %s \n' % len(checkbox_to_add)+'\n'.join(checkbox_to_add))
+        # add columns in data catalog but not in the table
+        checkbox_to_add = list(
+            set(checkbox_vars["variable"]) - set(checkbox_cols["variable"])
+        )
+        logger.info(
+            "Number of checkbox variables to add: %s \n" % len(checkbox_to_add)
+            + "\n".join(checkbox_to_add)
+        )
         # new checkbox columns
-        checkbox_cols_to_add = checkbox_vars_expanded[~checkbox_vars_expanded.col_name.isin(checkbox_cols['name'])]
+        checkbox_cols_to_add = checkbox_vars_expanded[
+            ~checkbox_vars_expanded.col_name.isin(checkbox_cols["name"])
+        ]
         if len(checkbox_cols_to_add) != 0:
-            checkbox_new_cols = list(checkbox_cols_to_add.apply(lambda x: create_synapse_column(x['col_name'],x['synColType'],x['synColSize']),axis=1))
+            checkbox_new_cols = list(
+                checkbox_cols_to_add.apply(
+                    lambda x: create_synapse_column(
+                        x["col_name"], x["synColType"], x["synColSize"]
+                    ),
+                    axis=1,
+                )
+            )
             cols_to_add = cols_to_add + checkbox_new_cols
-        logger.info('Number of new checkbox columns to add: %s \n' % checkbox_cols_to_add.shape[0]+'\n'.join(checkbox_cols_to_add['col_name']))
+        logger.info(
+            "Number of new checkbox columns to add: %s \n"
+            % checkbox_cols_to_add.shape[0]
+            + "\n".join(checkbox_cols_to_add["col_name"])
+        )
     # columns to update: STRING only
     # TODO: check all columnType
     cols_to_update = {}
     #   non-checkbox
-    non_check_str_cols = non_check_cols[non_check_cols.columnType=="STRING"]
-    merged_non_check_str = non_check_str_cols.merge(non_check_vars,how='left',left_on="name",right_on='variable')
-    non_check_str_update = merged_non_check_str.query('maximumSize < synColSize')
+    non_check_str_cols = non_check_cols[non_check_cols.columnType == "STRING"]
+    merged_non_check_str = non_check_str_cols.merge(
+        non_check_vars, how="left", left_on="name", right_on="variable"
+    )
+    non_check_str_update = merged_non_check_str.query("maximumSize < synColSize")
     if len(non_check_str_update) != 0:
-        for table in non_check_str_update.groupby('table_id'):
+        for table in non_check_str_update.groupby("table_id"):
             table_id = table[0]
             cols_to_update[table_id] = {}
-            cols_to_update[table_id]['new'] = list(table[1].apply(lambda x: create_synapse_column(x['variable'],x['synColType'],x['synColSize']),axis=1))
-            cols_to_update[table_id]['old'] = list(table[1]['id'])
-    logger.info('Number of non-checkbox columns to update: %s \n' % non_check_str_update.shape[0]+'\n'.join(non_check_str_update['variable']))
+            cols_to_update[table_id]["new"] = list(
+                table[1].apply(
+                    lambda x: create_synapse_column(
+                        x["variable"], x["synColType"], x["synColSize"]
+                    ),
+                    axis=1,
+                )
+            )
+            cols_to_update[table_id]["old"] = list(table[1]["id"])
+    logger.info(
+        "Number of non-checkbox columns to update: %s \n"
+        % non_check_str_update.shape[0]
+        + "\n".join(non_check_str_update["variable"])
+    )
     #   checkbox
     if len(checkbox_vars) != 0:
-        checkbox_str_cols = checkbox_cols[checkbox_cols.columnType=="STRING"]
-        merged_checkbox_str = checkbox_str_cols.merge(checkbox_vars_expanded,how='left',left_on='name',right_on='col_name')
-        checkbox_str_update = merged_checkbox_str.query('maximumSize < synColSize')
+        checkbox_str_cols = checkbox_cols[checkbox_cols.columnType == "STRING"]
+        merged_checkbox_str = checkbox_str_cols.merge(
+            checkbox_vars_expanded, how="left", left_on="name", right_on="col_name"
+        )
+        checkbox_str_update = merged_checkbox_str.query("maximumSize < synColSize")
         if len(checkbox_str_update) != 0:
-            for table in checkbox_str_update.groupby('table_id'):
+            for table in checkbox_str_update.groupby("table_id"):
                 table_id = table[0]
                 if table_id not in cols_to_update.keys():
                     cols_to_update[table_id] = {}
-                    cols_to_update[table_id]['new'] = list(table[1].apply(lambda x: create_synapse_column(x['name'],x['columnType'],x['synColSize']),axis=1))
-                    cols_to_update[table_id]['old'] = list(table[1]['id'])
+                    cols_to_update[table_id]["new"] = list(
+                        table[1].apply(
+                            lambda x: create_synapse_column(
+                                x["name"], x["columnType"], x["synColSize"]
+                            ),
+                            axis=1,
+                        )
+                    )
+                    cols_to_update[table_id]["old"] = list(table[1]["id"])
                 else:
-                    cols_to_update[table_id]['new'] = cols_to_update[table_id]['new'] + list(table[1].apply(lambda x: create_synapse_column(x['name'],x['columnType'],x['synColSize']),axis=1))
-                    cols_to_update[table_id]['old'] = cols_to_update[table_id]['old']+ list(table[1]['id'])
-        logger.info('Number of checkbox columns to update: %s \n' % checkbox_str_update.shape[0]+'\n'.join(checkbox_str_update['name']))
+                    cols_to_update[table_id]["new"] = cols_to_update[table_id][
+                        "new"
+                    ] + list(
+                        table[1].apply(
+                            lambda x: create_synapse_column(
+                                x["name"], x["columnType"], x["synColSize"]
+                            ),
+                            axis=1,
+                        )
+                    )
+                    cols_to_update[table_id]["old"] = cols_to_update[table_id][
+                        "old"
+                    ] + list(table[1]["id"])
+        logger.info(
+            "Number of checkbox columns to update: %s \n" % checkbox_str_update.shape[0]
+            + "\n".join(checkbox_str_update["name"])
+        )
     # TODO: columns to remove (IGNORE primary_key)
     if not dry_run:
         if len(cols_to_add) != 0:
-            #cols_to_add = syn.createColumns(cols_to_add)
+            # cols_to_add = syn.createColumns(cols_to_add)
             cols_to_add = [syn.store(i) for i in cols_to_add]
-            if tbl_with_least_cols_ct+len(cols_to_add) <= 152:
+            if tbl_with_least_cols_ct + len(cols_to_add) <= 152:
                 tbl_schema = syn.get(tbl_with_least_cols_id)
-                cols_to_add_id = [col['id'] for col in cols_to_add]
-                tbl_schema.columnIds = tbl_schema.columnIds+cols_to_add_id
+                cols_to_add_id = [col["id"] for col in cols_to_add]
+                tbl_schema.columnIds = tbl_schema.columnIds + cols_to_add_id
                 tbl_schema = syn.store(tbl_schema)
             else:
-                logger.info('TODO: need to add a new table')
+                # need a new table due to the maximum column limit of 152
+                logger.info("TODO: need to add a new table")
         if len(cols_to_update) != 0:
             for table_id in cols_to_update.keys():
                 tbl_schema = syn.get(table_id)
-                tbl_schema.columnIds = [ele for ele in tbl_schema.columnIds if ele not in cols_to_update[table_id]['old']]
-                cols_to_update_new = [syn.store(i) for i in cols_to_update[table_id]['new']]
-                cols_to_update_new_id = [col['id'] for col in cols_to_update_new]
-                tbl_schema.columnIds = tbl_schema.columnIds+cols_to_update_new_id
+                # extract columns that are not being updated
+                tbl_schema.columnIds = [
+                    ele
+                    for ele in tbl_schema.columnIds
+                    if ele not in cols_to_update[table_id]["old"]
+                ]
+                cols_to_update_new = [
+                    syn.store(i) for i in cols_to_update[table_id]["new"]
+                ]
+                cols_to_update_new_id = [col["id"] for col in cols_to_update_new]
+                tbl_schema.columnIds = tbl_schema.columnIds + cols_to_update_new_id
                 tbl_schema = syn.store(tbl_schema)
 
-def update_table_schema(syn, logger, dry_run):
+
+def update_table_schema(syn, logger, dry_run, TABLE_INFO):
     # get the data elements
-    curated_data_element = download_synapse_table(syn,"syn21431364","dataType='curated'")
-    curated_data_element = curated_data_element[['variable','instrument','type','synColType','synColSize','numCols','colLabels']]
-    # create the master table 
-    sage_table_view = download_synapse_table(syn,TABLE_INFO['sage'][0],TABLE_INFO['sage'][1])
-    sage_table_view.drop(columns='table_type',axis=1,inplace=True)
-    bpc_table_view = download_synapse_table(syn,TABLE_INFO['bpc'][0],TABLE_INFO['bpc'][1])
-    bpc_table_view = bpc_table_view[['id','name']]
-    irr_table_view = download_synapse_table(syn,TABLE_INFO['irr'][0],TABLE_INFO['irr'][1])
-    irr_table_view = irr_table_view[['id','name']]
-    irr_table_view['name'] = irr_table_view['name'].apply(lambda x: x.replace(' - double curated',''))
-    master_table_view = pandas.merge(sage_table_view, 
-                                     pandas.merge(bpc_table_view,irr_table_view,
-                                                  on='name',suffixes=['_bpc','_irr']),
-                                     on='name')
+    curated_data_element = download_synapse_table(
+        syn, TABLE_INFO["CATALOG_ID"], "dataType='curated'"
+    )
+    curated_data_element = curated_data_element[
+        [
+            "variable",
+            "instrument",
+            "type",
+            "synColType",
+            "synColSize",
+            "numCols",
+            "colLabels",
+        ]
+    ]
+    # create the master table
+    sage_table_view = download_synapse_table(
+        syn, TABLE_INFO["sage"][0], TABLE_INFO["sage"][1]
+    )
+    sage_table_view.drop(columns="table_type", axis=1, inplace=True)
+    bpc_table_view = download_synapse_table(
+        syn, TABLE_INFO["bpc"][0], TABLE_INFO["bpc"][1]
+    )
+    bpc_table_view = bpc_table_view[["id", "name"]]
+    irr_table_view = download_synapse_table(
+        syn, TABLE_INFO["irr"][0], TABLE_INFO["irr"][1]
+    )
+    irr_table_view = irr_table_view[["id", "name"]]
+    irr_table_view["name"] = irr_table_view["name"].apply(
+        lambda x: x.replace(" - double curated", "")
+    )
+    master_table_view = pandas.merge(
+        sage_table_view,
+        pandas.merge(
+            bpc_table_view, irr_table_view, on="name", suffixes=["_bpc", "_irr"]
+        ),
+        on="name",
+    )
     # update table schema for Sage Internal tables
-    form_groups = master_table_view.groupby('form')
+    form_groups = master_table_view.groupby("form")
     for form in form_groups:
         _update_table_schema(syn, form, curated_data_element, logger, dry_run)
     # copy the table schema to update the BPC Internal and IRR tables
     if not dry_run:
         logger.info("Updating table schemas for BPC and IRR tables")
         for _, row in master_table_view.iterrows():
-            new_bpc_schema = copy_table_schema(syn,row['id'],row['id_bpc'])
+            new_bpc_schema = copy_table_schema(syn, row["id"], row["id_bpc"])
             syn.store(new_bpc_schema)
-            new_irr_schema = copy_table_schema(syn,row['id'],row['id_irr'])
+            new_irr_schema = copy_table_schema(syn, row["id"], row["id_irr"])
             syn.store(new_irr_schema)
+
 
 def main():
     parser = argparse.ArgumentParser(
-        description='Update table schema on Synapse Tables for BPC')
+        description="Update table schema on Synapse Tables for BPC"
+    )
     parser.add_argument(
-        "-c", "--synapse_config",
+        "-c",
+        "--synapse_config",
         default=synapseclient.client.CONFIG_FILE,
-        help="Synapse credentials file")
+        help="Synapse credentials file",
+    )
+    parser.add_argument("-d", "--dry_run", action="store_true", help="dry run flag")
     parser.add_argument(
-        "-d", "--dry_run",
+        "-p",
+        "--production",
         action="store_true",
-        help="dry run flag"
+        help="Update production tables, default is staging.",
     )
 
     args = parser.parse_args()
     dry_run = args.dry_run
-    #login to synapse
+    # login to synapse
     syn = synapse_login(args.synapse_config)
 
-    #create logger
-    logger_name = "testing" if dry_run else "production"
+    # create logger
+    logger_name = "staging" if dry_run else "production"
     logger = setup_custom_logger(logger_name)
-    logger.info('Updating BPC Synapse Table schemas!')
+    logger.info("Updating BPC Synapse Table schemas!")
 
-    update_table_schema(syn,logger,dry_run)
+    if args.production:
+        TABLE_INFO = {
+            "CATALOG_ID": "syn21431364",
+            "sage": ("syn23285911", "table_type='data'"),
+            "bpc": ("syn21446696", "table_type='data' and double_curated is false"),
+            "irr": ("syn21446696", "table_type='data' and double_curated is true"),
+        }
+    else:
+        TABLE_INFO = {
+            "CATALOG_ID": "syn68893705",
+            "sage": ("syn63616766", "table_type='data'"),
+            "bpc": ("syn63617582", "table_type='data' and double_curated is false"),
+            "irr": ("syn63617582", "table_type='data' and double_curated is true"),
+        }
+
+    update_table_schema(syn, logger, dry_run, TABLE_INFO)
+
 
 if __name__ == "__main__":
     main()

--- a/scripts/table_updates/update_table_schema.py
+++ b/scripts/table_updates/update_table_schema.py
@@ -369,9 +369,6 @@ def update_table_schema(
     form_groups = master_table_view.groupby("form")
 
     for form in form_groups:
-        import pdb
-
-        pdb.set_trace()
         _update_table_schema(syn, form, curated_data_element, logger, dry_run)
     # copy the table schema to update the BPC Internal and IRR tables
     if not dry_run:
@@ -381,7 +378,6 @@ def update_table_schema(
             syn.store(new_bpc_schema)
             # new_irr_schema = copy_table_schema(syn, row["id"], row["id_irr"])
             # syn.store(new_irr_schema)
-
 
 def main():
     parser = argparse.ArgumentParser(

--- a/scripts/table_updates/update_table_schema.py
+++ b/scripts/table_updates/update_table_schema.py
@@ -19,7 +19,7 @@ def copy_table_schema(syn, from_table_id, to_table_id):
 
 def create_synapse_column(name, col_type, max_size):
     """
-    Create a new Synapse Column with given info. ??? may extend, string. use data element column types
+    Create a new Synapse Column with given info.
     """
     if col_type in ["INTEGER", "DOUBLE", "LARGETEXT"]:
         new_column = Column(name=name, columnType=col_type)

--- a/scripts/table_updates/update_table_schema.py
+++ b/scripts/table_updates/update_table_schema.py
@@ -85,7 +85,7 @@ def _get_latest_table(form: tuple) -> str:
     if form[1].shape[0] == 1:
         return form[1]["id"].values[0]
     else:
-        # get the table with latest numeric suffix
+        # get the table with latest numeric suffix. For example, for Prissmm Pathology tables, it will give 6 becasue Prissmm Pathology Part 6 has the largest Part number.
         latest_part_number = max(form[1]["name"].str.extract(r"(\d+)$")[0].astype(int))
         latest_table = form[1][form[1]["name"].str.contains(f" {latest_part_number}$")]
         return latest_table["id"].values[0]
@@ -309,11 +309,23 @@ def update_table_schema(
     syn: synapseclient.Synapse,
     logger: logging,
     dry_run: bool,
-    TABLE_INFO: dict[str, tuple],
+    table_info: dict[str, tuple],
 ) -> None:
+    """
+    Update the table schema for BPC and IRR tables based on the curated data element catalog and Sage Internal tables.
+
+    Notes:
+        Updating IRR tables is currently commented out in case it is needed for phase 3.
+
+    Args:
+        syn (synapseclient.Synapse): Synapse client object
+        logger (logging): Logger object for logging information
+        dry_run (bool): If True, do not save any changes to Synapse tables
+        table_info (dict): A dictionary containing Synapse table IDs and conditions for catalog, Sage, BPC, and IRR tables.
+    """
     # get the data elements
     curated_data_element = download_synapse_table(
-        syn, table_id=TABLE_INFO["catalog_id"], condition="dataType='curated'"
+        syn, table_id=table_info["catalog_id"], condition="dataType='curated'"
     )
     curated_data_element = curated_data_element[
         [
@@ -328,16 +340,16 @@ def update_table_schema(
     ]
     # create the master table
     sage_table_view = download_synapse_table(
-        syn, table_id=TABLE_INFO["sage"][0], condition=TABLE_INFO["sage"][1]
+        syn, table_id=table_info["sage"][0], condition=table_info["sage"][1]
     )
     sage_table_view.drop(columns="table_type", axis=1, inplace=True)
     bpc_table_view = download_synapse_table(
-        syn, table_id=TABLE_INFO["bpc"][0], condition=TABLE_INFO["bpc"][1]
+        syn, table_id=table_info["bpc"][0], condition=table_info["bpc"][1]
     )
     bpc_table_view = bpc_table_view[["id", "name"]]
     ## comment out irr for now in case it is needed for phase 3
     # irr_table_view = download_synapse_table(
-    #     syn, table_id=TABLE_INFO["irr"][0], condition=TABLE_INFO["irr"][1]
+    #     syn, table_id=table_info["irr"][0], condition=table_info["irr"][1]
     # )
     # irr_table_view = irr_table_view[["id", "name"]]
     # irr_table_view["name"] = irr_table_view["name"].apply(
@@ -355,11 +367,15 @@ def update_table_schema(
     # )
     # update table schema for Sage Internal tables. Grouping by form since some forms have multiple tables
     form_groups = master_table_view.groupby("form")
+
     for form in form_groups:
+        import pdb
+
+        pdb.set_trace()
         _update_table_schema(syn, form, curated_data_element, logger, dry_run)
     # copy the table schema to update the BPC Internal and IRR tables
     if not dry_run:
-        logger.info("Updating table schemas for BPC and IRR tables")
+        logger.info("Updating table schemas for BPC tables")
         for _, row in master_table_view.iterrows():
             new_bpc_schema = copy_table_schema(syn, row["id"], row["id_bpc"])
             syn.store(new_bpc_schema)
@@ -391,21 +407,21 @@ def main():
     logger.info("Updating BPC Synapse Table schemas!")
 
     if args.production:
-        TABLE_INFO = {
+        table_info = {
             "catalog_id": "syn21431364",
             "sage": ("syn23285911", "table_type='data'"),
             "bpc": ("syn21446696", "table_type='data' and double_curated is false"),
             "irr": ("syn21446696", "table_type='data' and double_curated is true"),
         }
     else:
-        TABLE_INFO = {
+        table_info = {
             "catalog_id": "syn68893705",
             "sage": ("syn63616766", "table_type='data'"),
             "bpc": ("syn63617582", "table_type='data' and double_curated is false"),
             "irr": ("syn63617582", "table_type='data' and double_curated is true"),
         }
 
-    update_table_schema(syn, logger, dry_run, TABLE_INFO)
+    update_table_schema(syn, logger, dry_run, table_info)
 
 
 if __name__ == "__main__":

--- a/scripts/table_updates/update_table_schema.py
+++ b/scripts/table_updates/update_table_schema.py
@@ -279,6 +279,7 @@ def _update_table_schema(
         if len(cols_to_add) != 0:
             # cols_to_add = syn.createColumns(cols_to_add)
             cols_to_add = [syn.store(i) for i in cols_to_add]
+            # the maximum number of columns in a Synapse table is 152 when the code was developed, so we keep it as is.
             if latest_table_col_ct + len(cols_to_add) <= 152:
                 tbl_schema = syn.get(latest_table_id)
                 cols_to_add_id = [col["id"] for col in cols_to_add]
@@ -378,6 +379,7 @@ def update_table_schema(
             syn.store(new_bpc_schema)
             # new_irr_schema = copy_table_schema(syn, row["id"], row["id_irr"])
             # syn.store(new_irr_schema)
+
 
 def main():
     parser = argparse.ArgumentParser(

--- a/scripts/table_updates/update_table_schema.py
+++ b/scripts/table_updates/update_table_schema.py
@@ -70,9 +70,6 @@ def _get_latest_table(form) -> str:
 
 
 def _update_table_schema(syn, form, curated_data_element, logger, dry_run):
-    import pdb
-
-    pdb.set_trace()
     form_name = form[0]
     form_df = form[1]
     form_name_list = form_name.split(", ")
@@ -322,8 +319,8 @@ def update_table_schema(syn, logger, dry_run, TABLE_INFO):
         for _, row in master_table_view.iterrows():
             new_bpc_schema = copy_table_schema(syn, row["id"], row["id_bpc"])
             syn.store(new_bpc_schema)
-            new_irr_schema = copy_table_schema(syn, row["id"], row["id_irr"])
-            syn.store(new_irr_schema)
+            #new_irr_schema = copy_table_schema(syn, row["id"], row["id_irr"])
+            #syn.store(new_irr_schema)
 
 
 def main():

--- a/scripts/table_updates/update_table_schema.py
+++ b/scripts/table_updates/update_table_schema.py
@@ -50,26 +50,47 @@ def _expand_checkbox_vars(row):
         return pandas.DataFrame(temp_df_list)
 
 
+def _get_latest_table(form) -> str:
+    """get the latest table for each form
+
+    Args:
+        form (tuple): the tuple of the form and the corresponding tables outputed by groupby
+        e.g. ["form_name": a dataframe contains basic informatiohn for tables associated with the form, including id, name, etc.]
+
+    Returns:
+        string: the table id of the table with the latest numeric suffix
+    """
+    if form[1].shape[0] == 1:
+        return form[1]["id"].values[0]
+    else:
+        # get the table with latest numeric suffix
+        latest_part_number = max(form[1]["name"].str.extract(r"(\d+)$")[0].astype(int))
+        latest_table = form[1][form[1]["name"].str.contains(f" {latest_part_number}$")]
+        return latest_table["id"].values[0]
+
+
 def _update_table_schema(syn, form, curated_data_element, logger, dry_run):
     form_name = form[0]
     form_df = form[1]
     form_name_list = form_name.split(", ")
     logger.info("Checking %s" % form_name)
-    # get the data frame of variables
+    # get the data frame of variables for the form
     vars_dec = curated_data_element[
         curated_data_element.instrument.isin(form_name_list)
     ]
-    # get the data frame of existing columns
+    # get the data frame of existing columns in the tables
     current_cols_df = pandas.DataFrame()
     for _, row in form_df.iterrows():
         current_cols = syn.getColumns(row["id"])
         current_cols = pandas.DataFrame(current_cols)
         current_cols["table_id"] = row["id"]
         current_cols_df = pandas.concat([current_cols_df, current_cols])
-    # get the table id with the least columns
-    tbl_with_least_cols = current_cols_df["table_id"].value_counts()
-    tbl_with_least_cols_id = tbl_with_least_cols.idxmin()
-    tbl_with_least_cols_ct = tbl_with_least_cols.min()
+    # get the table id for the newest table
+    latest_table_id = _get_latest_table(form)
+    # get the column count of latest table
+    latest_table_col_ct = current_cols_df.loc[
+        current_cols_df.table_id == latest_table_id
+    ].shape[0]
     # Compare the data element catalog and the current table columns
     # non-checkbox
     non_check_vars = vars_dec[vars_dec.type != "checkbox"]
@@ -77,14 +98,17 @@ def _update_table_schema(syn, form, curated_data_element, logger, dry_run):
     # checkbox
     checkbox_vars = vars_dec[vars_dec.type == "checkbox"]
     if len(checkbox_vars) != 0:
+        # genereate checkbox columns by combining variable and colLabels, each column is named as variable___label
         checkbox_vars_expanded = pandas.concat(
             list(checkbox_vars.apply(lambda row: _expand_checkbox_vars(row), axis=1)),
             ignore_index=True,
         )
+        # existing checkbox columns and generate the variable column for later logger info
         checkbox_cols = current_cols_df[current_cols_df["name"].str.contains("___")]
         checkbox_cols["variable"] = checkbox_cols["name"].str.split("___", expand=True)[
             0
         ]
+
     # columns to add
     cols_to_add = []
     #  non-checkbox
@@ -96,6 +120,7 @@ def _update_table_schema(syn, form, curated_data_element, logger, dry_run):
         non_check_to_add_df = non_check_vars[
             non_check_vars.variable.isin(non_check_to_add)
         ]
+        # create Column objects for new columns
         non_check_new_cols = list(
             non_check_to_add_df.apply(
                 lambda x: create_synapse_column(
@@ -140,6 +165,7 @@ def _update_table_schema(syn, form, curated_data_element, logger, dry_run):
             % checkbox_cols_to_add.shape[0]
             + "\n".join(checkbox_cols_to_add["col_name"])
         )
+
     # columns to update: STRING only
     # TODO: check all columnType
     cols_to_update = {}
@@ -161,6 +187,7 @@ def _update_table_schema(syn, form, curated_data_element, logger, dry_run):
                     axis=1,
                 )
             )
+            # save column id to "old" column
             cols_to_update[table_id]["old"] = list(table[1]["id"])
     logger.info(
         "Number of non-checkbox columns to update: %s \n"
@@ -173,6 +200,7 @@ def _update_table_schema(syn, form, curated_data_element, logger, dry_run):
         merged_checkbox_str = checkbox_str_cols.merge(
             checkbox_vars_expanded, how="left", left_on="name", right_on="col_name"
         )
+        # update string checkbox columns if maximumSize is less than synColSize
         checkbox_str_update = merged_checkbox_str.query("maximumSize < synColSize")
         if len(checkbox_str_update) != 0:
             for table in checkbox_str_update.groupby("table_id"):
@@ -189,6 +217,7 @@ def _update_table_schema(syn, form, curated_data_element, logger, dry_run):
                     )
                     cols_to_update[table_id]["old"] = list(table[1]["id"])
                 else:
+                    # extend the existing lists if table_id is already tracked in non-check section
                     cols_to_update[table_id]["new"] = cols_to_update[table_id][
                         "new"
                     ] + list(
@@ -211,8 +240,8 @@ def _update_table_schema(syn, form, curated_data_element, logger, dry_run):
         if len(cols_to_add) != 0:
             # cols_to_add = syn.createColumns(cols_to_add)
             cols_to_add = [syn.store(i) for i in cols_to_add]
-            if tbl_with_least_cols_ct + len(cols_to_add) <= 152:
-                tbl_schema = syn.get(tbl_with_least_cols_id)
+            if latest_table_col_ct + len(cols_to_add) <= 152:
+                tbl_schema = syn.get(latest_table_id)
                 cols_to_add_id = [col["id"] for col in cols_to_add]
                 tbl_schema.columnIds = tbl_schema.columnIds + cols_to_add_id
                 tbl_schema = syn.store(tbl_schema)
@@ -222,12 +251,13 @@ def _update_table_schema(syn, form, curated_data_element, logger, dry_run):
         if len(cols_to_update) != 0:
             for table_id in cols_to_update.keys():
                 tbl_schema = syn.get(table_id)
-                # extract columns that are not being updated
+                # extract columns that are not to be updated
                 tbl_schema.columnIds = [
                     ele
                     for ele in tbl_schema.columnIds
                     if ele not in cols_to_update[table_id]["old"]
                 ]
+                # save updated columns to Synapse and get their ids
                 cols_to_update_new = [
                     syn.store(i) for i in cols_to_update[table_id]["new"]
                 ]
@@ -239,7 +269,7 @@ def _update_table_schema(syn, form, curated_data_element, logger, dry_run):
 def update_table_schema(syn, logger, dry_run, TABLE_INFO):
     # get the data elements
     curated_data_element = download_synapse_table(
-        syn, TABLE_INFO["CATALOG_ID"], "dataType='curated'"
+        syn, table_id=TABLE_INFO["CATALOG_ID"], condition="dataType='curated'"
     )
     curated_data_element = curated_data_element[
         [
@@ -254,28 +284,32 @@ def update_table_schema(syn, logger, dry_run, TABLE_INFO):
     ]
     # create the master table
     sage_table_view = download_synapse_table(
-        syn, TABLE_INFO["sage"][0], TABLE_INFO["sage"][1]
+        syn, table_id=TABLE_INFO["sage"][0], condition=TABLE_INFO["sage"][1]
     )
     sage_table_view.drop(columns="table_type", axis=1, inplace=True)
     bpc_table_view = download_synapse_table(
-        syn, TABLE_INFO["bpc"][0], TABLE_INFO["bpc"][1]
+        syn, table_id=TABLE_INFO["bpc"][0], condition=TABLE_INFO["bpc"][1]
     )
     bpc_table_view = bpc_table_view[["id", "name"]]
-    irr_table_view = download_synapse_table(
-        syn, TABLE_INFO["irr"][0], TABLE_INFO["irr"][1]
-    )
-    irr_table_view = irr_table_view[["id", "name"]]
-    irr_table_view["name"] = irr_table_view["name"].apply(
-        lambda x: x.replace(" - double curated", "")
-    )
+    ## comment out irr for now in case it is needed for phase 3
+    # irr_table_view = download_synapse_table(
+    #     syn, table_id=TABLE_INFO["irr"][0], condition=TABLE_INFO["irr"][1]
+    # )
+    # irr_table_view = irr_table_view[["id", "name"]]
+    # irr_table_view["name"] = irr_table_view["name"].apply(
+    #     lambda x: x.replace(" - double curated", "")
+    # )
     master_table_view = pandas.merge(
-        sage_table_view,
-        pandas.merge(
-            bpc_table_view, irr_table_view, on="name", suffixes=["_bpc", "_irr"]
-        ),
-        on="name",
+        sage_table_view, bpc_table_view, on="name", suffixes=["", "_bpc"]
     )
-    # update table schema for Sage Internal tables
+    # master_table_view = pandas.merge(
+    #     sage_table_view,
+    #     pandas.merge(
+    #         bpc_table_view, irr_table_view, on="name", suffixes=["_bpc", "_irr"]
+    #     ),
+    #     on="name",
+    # )
+    # update table schema for Sage Internal tables. Grouping by form since some forms have multiple tables
     form_groups = master_table_view.groupby("form")
     for form in form_groups:
         _update_table_schema(syn, form, curated_data_element, logger, dry_run)

--- a/scripts/table_updates/update_table_schema.py
+++ b/scripts/table_updates/update_table_schema.py
@@ -7,9 +7,19 @@ from synapseclient import Column
 from utilities import *
 
 
-def copy_table_schema(syn, from_table_id, to_table_id):
+def copy_table_schema(
+    syn: synapseclient.Synapse, from_table_id: str, to_table_id: str
+) -> synapseclient.table.Schema:
     """
     Copy table schema from one table to another
+
+    Args:
+        syn (synapseclient.Synapse): Synapse client object
+        from_table_id (str): Source table id
+        to_table_id (str): Target table id
+
+    Returns:
+        synapseclient.table.Schema: Updated schema of the target table
     """
     from_table_schema = syn.get(from_table_id)
     to_table_schema = syn.get(to_table_id)
@@ -17,9 +27,19 @@ def copy_table_schema(syn, from_table_id, to_table_id):
     return to_table_schema
 
 
-def create_synapse_column(name, col_type, max_size):
+def create_synapse_column(
+    name: str, col_type: str, max_size: int | float
+) -> synapseclient.table.Column:
     """
     Create a new Synapse Column with given info.
+
+    Args:
+        name (str): Column name
+        col_type (str): Column type
+        max_size (int or float): Maximum size for STRING type columns
+
+    Returns:
+        synapseclient.table.Column: A Synapse Column object
     """
     if col_type in ["INTEGER", "DOUBLE", "LARGETEXT"]:
         new_column = Column(name=name, columnType=col_type)
@@ -29,12 +49,13 @@ def create_synapse_column(name, col_type, max_size):
     return new_column
 
 
-def _expand_checkbox_vars(row):
-    """Expand checkbox variables into multiple columns
+def _expand_checkbox_vars(row: pandas.Series) -> pandas.DataFrame:
+    """
+    Expand checkbox variables in the GENIE BPC No PHI Data Elements Catalog table into multiple columns.
+    Each colLabel will be expanded into a separate column named as variable___label, such as ca_qatype___1.
 
     Args:
-        row (pd.Series): A row of the data element dataframe
-
+        row (pandas.Series): A row of the Data Elements Catalog dataframe
     Returns:
         pandas.DataFrame: A dataframe with expanded checkbox variables
     """
@@ -50,15 +71,16 @@ def _expand_checkbox_vars(row):
         return pandas.DataFrame(temp_df_list)
 
 
-def _get_latest_table(form) -> str:
-    """get the latest table for each form
+def _get_latest_table(form: tuple) -> str:
+    """
+    Get the synapse id of the latest table for each form
 
     Args:
-        form (tuple): the tuple of the form and the corresponding tables outputed by groupby
+        form (tuple): the tuple of the form and its corresponding tables outputed by pandas.DataFrame.groupby function, such as master_table_view.groupby("form").
         e.g. ["form_name": a dataframe contains basic informatiohn for tables associated with the form, including id, name, etc.]
 
     Returns:
-        string: the table id of the table with the latest numeric suffix
+        string: The synapse id of the table with the latest numeric suffix
     """
     if form[1].shape[0] == 1:
         return form[1]["id"].values[0]
@@ -69,7 +91,24 @@ def _get_latest_table(form) -> str:
         return latest_table["id"].values[0]
 
 
-def _update_table_schema(syn, form, curated_data_element, logger, dry_run):
+def _update_table_schema(
+    syn: synapseclient.Synapse,
+    form: tuple[str, pandas.DataFrame],
+    curated_data_element: pandas.DataFrame,
+    logger: logging,
+    dry_run: bool,
+) -> None:
+    """
+    Update the table schema for a given form based on the curated data element catalog.
+    It checks for new columns to add, existing columns to update, and columns to remove (TODO).
+    Args:
+        syn (synapseclient.Synapse): Synapse client object
+        form (tuple): the tuple of the form and its corresponding tables outputed by pandas.DataFrame.groupby function, such as master_table_view.groupby("form").
+        e.g. ["form_name": a dataframe contains basic informatiohn for tables associated with the form, including id, name, etc.]
+        curated_data_element (pandas.DataFrame): Dataframe of the curated data element catalog
+        logger (logging): Logger object for logging information
+        dry_run (bool): If True, do not save any changes to Synapse tables
+    """
     form_name = form[0]
     form_df = form[1]
     form_name_list = form_name.split(", ")
@@ -266,7 +305,12 @@ def _update_table_schema(syn, form, curated_data_element, logger, dry_run):
                 tbl_schema = syn.store(tbl_schema)
 
 
-def update_table_schema(syn, logger, dry_run, TABLE_INFO):
+def update_table_schema(
+    syn: synapseclient.Synapse,
+    logger: logging,
+    dry_run: bool,
+    TABLE_INFO: dict[str, tuple],
+) -> None:
     # get the data elements
     curated_data_element = download_synapse_table(
         syn, table_id=TABLE_INFO["catalog_id"], condition="dataType='curated'"
@@ -319,8 +363,8 @@ def update_table_schema(syn, logger, dry_run, TABLE_INFO):
         for _, row in master_table_view.iterrows():
             new_bpc_schema = copy_table_schema(syn, row["id"], row["id_bpc"])
             syn.store(new_bpc_schema)
-            #new_irr_schema = copy_table_schema(syn, row["id"], row["id_irr"])
-            #syn.store(new_irr_schema)
+            # new_irr_schema = copy_table_schema(syn, row["id"], row["id_irr"])
+            # syn.store(new_irr_schema)
 
 
 def main():

--- a/scripts/table_updates/update_table_schema.py
+++ b/scripts/table_updates/update_table_schema.py
@@ -269,7 +269,7 @@ def _update_table_schema(syn, form, curated_data_element, logger, dry_run):
 def update_table_schema(syn, logger, dry_run, TABLE_INFO):
     # get the data elements
     curated_data_element = download_synapse_table(
-        syn, table_id=TABLE_INFO["CATALOG_ID"], condition="dataType='curated'"
+        syn, table_id=TABLE_INFO["catalog_id"], condition="dataType='curated'"
     )
     curated_data_element = curated_data_element[
         [
@@ -327,12 +327,7 @@ def main():
     parser = argparse.ArgumentParser(
         description="Update table schema on Synapse Tables for BPC"
     )
-    parser.add_argument(
-        "-c",
-        "--synapse_config",
-        default=synapseclient.client.CONFIG_FILE,
-        help="Synapse credentials file",
-    )
+    parser.add_argument("--debug", action="store_true", help="Synapse Debug Feature")
     parser.add_argument("-d", "--dry_run", action="store_true", help="dry run flag")
     parser.add_argument(
         "-p",
@@ -344,7 +339,7 @@ def main():
     args = parser.parse_args()
     dry_run = args.dry_run
     # login to synapse
-    syn = synapse_login(args.synapse_config)
+    syn = synapse_login(debug=args.debug)
 
     # create logger
     logger_name = "staging" if dry_run else "production"
@@ -353,14 +348,14 @@ def main():
 
     if args.production:
         TABLE_INFO = {
-            "CATALOG_ID": "syn21431364",
+            "catalog_id": "syn21431364",
             "sage": ("syn23285911", "table_type='data'"),
             "bpc": ("syn21446696", "table_type='data' and double_curated is false"),
             "irr": ("syn21446696", "table_type='data' and double_curated is true"),
         }
     else:
         TABLE_INFO = {
-            "CATALOG_ID": "syn68893705",
+            "catalog_id": "syn68893705",
             "sage": ("syn63616766", "table_type='data'"),
             "bpc": ("syn63617582", "table_type='data' and double_curated is false"),
             "irr": ("syn63617582", "table_type='data' and double_curated is true"),

--- a/scripts/table_updates/update_table_schema.py
+++ b/scripts/table_updates/update_table_schema.py
@@ -70,6 +70,9 @@ def _get_latest_table(form) -> str:
 
 
 def _update_table_schema(syn, form, curated_data_element, logger, dry_run):
+    import pdb
+
+    pdb.set_trace()
     form_name = form[0]
     form_df = form[1]
     form_name_list = form_name.split(", ")

--- a/scripts/table_updates/utilities.py
+++ b/scripts/table_updates/utilities.py
@@ -2,11 +2,11 @@
 import builtins
 import logging
 import sys
-from typing import List, Tuple
+from typing import Boolean, List, Optional, Tuple
 
 import pandas
 import synapseclient
-from synapseclient import Schema, Table
+from synapseclient import Schema, Synapse, Table
 
 builtins.na_values = [
     "-1.#IND",
@@ -145,20 +145,28 @@ def setup_custom_logger(name):
     return logger
 
 
-def synapse_login(synapse_config):
-    """Log into Synapse
+def synapse_login(debug: Optional[bool] = False) -> Synapse:
+    """
+    Logs into Synapse if credentials are saved.
+    If not saved, then user is prompted username and auth token.
 
     Args:
-        synapse_config (String): File path to the Synapse config file
+        debug: Synapse debug feature. Defaults to False
 
     Returns:
-        Synapse object
+        Synapseclient object
     """
+    # If debug is True, then silent should be False
+    silent = False if debug else False
+    syn = synapseclient.Synapse(debug=debug, silent=silent)
     try:
-        syn = synapseclient.login(silent=True)
-    except Exception:
-        syn = synapseclient.Synapse(configPath=synapse_config, silent=True)
         syn.login()
+    except Exception:
+        raise ValueError(
+            "Please view https://help.synapse.org/docs/Client-Configuration.1985446156.html"
+            "to configure authentication to the client.  Configure a ~/.synapseConfig"
+            "or set the SYNAPSE_AUTH_TOKEN environmental variable."
+        )
     return syn
 
 

--- a/scripts/table_updates/utilities.py
+++ b/scripts/table_updates/utilities.py
@@ -2,7 +2,7 @@
 import builtins
 import logging
 import sys
-from typing import Boolean, List, Optional, Tuple
+from typing import List, Optional, Tuple
 
 import pandas
 import synapseclient


### PR DESCRIPTION
# **Problem:**

Currently, schema updates in the BPC tables are being applied directly to production whenever changes are required. This approach introduces unnecessary risk, as any issues with the updates—such as mismatched schemas, dropped columns, or data integrity problems—immediately impact production data.

In addition, the pipeline scripts need to be updated to reflect recent changes:

1. Remove all Synapse configuration references, since credentials are now passed through the SYNAPSE_AUTH_TOKEN environment variable.
2. Introduce a table version to indicate which data dictionary was used when updating the data element catalog table.
3. Comment out all IRR-related sections, as we no longer intend to update the IRR table schema.
4. Fix the logic in update_table_schema.py for selecting the target table to which new columns are appended, since it does not currently align with the intended usage.

# **Solution:**

1. Updated the synapse_login functions in utilities module and update corresponding functions in each impacted 
2. Update update_data_element_catalog and update_table_schema.py and update_data_table.py to adapt the new `synapse_login` functions.
4. Tweak functions and logic to address problems mentioned in the above section. 
5. Add staging mode to [update_table_schema.py](https://github.com/Sage-Bionetworks/genie-bpc-pipeline/blob/develop/scripts/table_updates/update_table_schema.py) and [update_data_element_catalog.py](https://github.com/Sage-Bionetworks/genie-bpc-pipeline/blob/develop/scripts/table_updates/update_data_element_catalog.py ) 

# **Testing:**
1. Successfully finished testing update_data_element_catalog.py. 
6. Successfully finished testing update_table_schema.py.