### PR TITLE
[GEN-2256] add RENAL data to cbio mapping table

### DIFF
--- a/scripts/references/update_cbio_mapping.py
+++ b/scripts/references/update_cbio_mapping.py
@@ -28,7 +28,7 @@ def main(save_to_synapse, comment, verbose):
     # Parameters
     file_id = "syn25585554"
     tbl_id = "syn25712693"
-    cohorts = ["NSCLC", "CRC", "BrCa", "PANC", "Prostate", "BLADDER"]
+    cohorts = ["NSCLC", "CRC", "BrCa", "PANC", "Prostate", "BLADDER", "RENAL"]
     outfile = "cbio_mapping_table_update.csv"
 
     # Synapse login


### PR DESCRIPTION
# **Problem:**

The `update_cbio_mapping.py` script updates the table on Synapse, but not adding the RENAL cohort data. 

# **Solution:**

1. Add `RENAL` to cohorts list so this cohort will be extracted.
2. Add `RENAL` column to BPC REDCap to cbio mapping table on Synapse. 

# **Testing:**
The renal data is added to the [BPC REDCap to cbio mapping table](https://www.synapse.org/Synapse:syn25712693/tables/).