### PR TITLE
[GEN-2025]fix ValueError: Cannot index with multidimensional key in data catalog update script

### DIFF
--- a/scripts/table_updates/update_data_element_catalog.py
+++ b/scripts/table_updates/update_data_element_catalog.py
@@ -229,7 +229,7 @@ def _update_by_data_dictionary(
     )
     logger.info(
         "Updated both columns size and number: %s \n" % vars_to_update_checkbox.shape[0]
-        + "\n".join(vars_to_update_checkbox.loc[vars_to_update_checkbox, "variable"])
+        + "\n".join(vars_to_update_checkbox["variable"])
     )
     return vars_to_add_df, vars_to_rm_df, vars_to_update_df
 


### PR DESCRIPTION
# **Problem:**
The issue: "ValueError: Cannot index with multidimensional key" was found earlier but being forgotten to be added to the original PR. 
<img width="1396" height="329" alt="Screenshot 2025-09-08 at 11 54 19 AM" src="https://github.com/user-attachments/assets/721b9337-d99b-4453-897d-66a929bf7b71" />

# **Solution:**
Add the fix. 

# **Testing:**

The issue is solved by including the fix. 
<img width="1476" height="247" alt="Screenshot 2025-09-08 at 11 54 11 AM" src="https://github.com/user-attachments/assets/d98a1cbe-f91c-4df7-9de7-ab150ad6e3b2" />
