### PR TITLE
[GEN-2043] Refactor timezone conversion in update_cbio_mapping.py

### DIFF
--- a/scripts/references/update_cbio_mapping.py
+++ b/scripts/references/update_cbio_mapping.py
@@ -1,10 +1,10 @@
 import argparse
 from datetime import datetime
-
 import pandas as pd
+import pytz
+
 import synapseclient
 from synapseclient import Table
-
 
 def now(time_only=False, tz="US/Pacific"):
     if time_only:
@@ -48,7 +48,9 @@ def main(save_to_synapse, comment, verbose):
     # Mapping
     if comment is None:
         utc_mod = entity.modifiedOn
-        pt_mod = utc_mod.replace(tzinfo=synapseclient.utils.from_tz_string("America/Los_Angeles"))
+        utc_datetime = datetime.fromisoformat(utc_mod[:-1]).replace(tzinfo=pytz.utc)
+        pt_timezone = pytz.timezone('US/Pacific')
+        pt_mod = utc_datetime.astimezone(pt_timezone)
         comment = f"mapping file update from {pt_mod.strftime('%Y-%m-%d')} PT ({file_id}.{entity.versionNumber})"
 
     if verbose:

--- a/scripts/references/update_cbio_mapping.py
+++ b/scripts/references/update_cbio_mapping.py
@@ -48,7 +48,8 @@ def main(save_to_synapse, comment, verbose):
     # Mapping
     if comment is None:
         utc_mod = entity.modifiedOn
-        utc_datetime = datetime.fromisoformat(utc_mod[:-1]).replace(tzinfo=pytz.utc)
+        # Remove trailing 'Z' from ISO 8601 UTC timestamp (e.g., '2024-06-10T12:34:56Z')
+        utc_datetime = datetime.fromisoformat(utc_mod.rstrip('Z')).replace(tzinfo=pytz.utc)
         pt_timezone = pytz.timezone('US/Pacific')
         pt_mod = utc_datetime.astimezone(pt_timezone)
         comment = f"mapping file update from {pt_mod.strftime('%Y-%m-%d')} PT ({file_id}.{entity.versionNumber})"


### PR DESCRIPTION
Updated timezone handling for modified timestamps using pytz.

# **Problem:**
Refactor timezone conversion due to synutils cannot be used.

# **Solution:**
Update to use pytz instead